### PR TITLE
Command-line options and Javadoc output

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -9,7 +9,7 @@ Libraries used by Toradocu
 * ```lib/tools-jdk1.8.0_72.jar``` (part of the standard Oracle's JDK distribution, 
   license [here](http://www.oracle.com/technetwork/java/javase/terms/license/index.html).
 * Other libraries are automatically fetched by the building system and are listed in ```toradocu/build.gradle```.  
-  Please refer to individual linceses.
+  Please refer to individual licenses.
   
 
 The MIT License (MIT)

--- a/src/main/java/org/toradocu/Toradocu.java
+++ b/src/main/java/org/toradocu/Toradocu.java
@@ -23,6 +23,7 @@ import org.toradocu.extractor.JavadocExtractor;
 import org.toradocu.util.NullOutputStream;
 
 import com.beust.jcommander.JCommander;
+import com.beust.jcommander.ParameterException;
 import com.sun.javadoc.ClassDoc;
 import com.sun.tools.javadoc.Main;
 
@@ -33,7 +34,13 @@ public class Toradocu {
 	private static final Configuration CONF = Configuration.INSTANCE;
 	
 	public static void main(String[] args) {
-		JCommander options = new JCommander(CONF, args);
+		JCommander options;
+		try {
+			options = new JCommander(CONF, args);
+		} catch (ParameterException e) {
+			System.out.println(e.getMessage());
+			return;
+		}
 		options.setProgramName(PROGRAM_NAME);
 		
 		if (CONF.help()) {

--- a/src/main/java/org/toradocu/conf/Configuration.java
+++ b/src/main/java/org/toradocu/conf/Configuration.java
@@ -1,6 +1,8 @@
 package org.toradocu.conf;
 
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -47,11 +49,14 @@ public enum Configuration {
 	@DynamicParameter(names = "-J", description = "Javadoc options")
 	private Map<String, String> javadocOptions = new HashMap<>();
 	
+// Temporary Javadoc output directory
+	private String tempJavadocOutputDir;
+	
 // Constants
 	
 	private final String aspectTemplate = "AspectTemplate.java";
 
-// ====================
+// Getters
 	
 	public boolean isOracleGenerationEnabled() {
 		return oracleGeneration;
@@ -71,6 +76,17 @@ public enum Configuration {
 	
 	public String getTargetClass() {
 		return targetClass;
+	}
+	
+	/**
+	 * Returns a temporary directory for Javadoc output or null if a
+	 * non-temporary directory is set for Javadoc output.
+	 * 
+	 * @return a temporary directory for Javadoc output or null if a
+	 * non-temporary directory is set for Javadoc output
+	 */
+	public String getTempJavadocOutputDir() {
+		return tempJavadocOutputDir;
 	}
 	
 	public File getConditionTranslatorOutput() {
@@ -96,6 +112,18 @@ public enum Configuration {
 		if (!arguments.contains("-quiet")) {
 			arguments.add("-quiet");
 		}
+		
+		// Use a temporary Javadoc output directory if one is not specified
+		if (!arguments.contains("-d")) {
+			try {
+				tempJavadocOutputDir = Files.createTempDirectory(null).toString();
+				arguments.add("-d");
+				arguments.add(tempJavadocOutputDir);
+			} catch (IOException e) {
+				// Output to working directory instead.
+			}
+		}
+		
 		arguments.add(getTargetPackage());
 		return arguments.toArray(new String[0]);
 	}

--- a/src/main/java/org/toradocu/doclet/standard/Standard.java
+++ b/src/main/java/org/toradocu/doclet/standard/Standard.java
@@ -26,7 +26,7 @@
 package org.toradocu.doclet.standard;
 
 import com.sun.javadoc.*;
-import org.toradocu.doclet.formats.html.*;
+import org.toradocu.doclet.formats.html.HtmlDoclet;
 
 
 public class Standard {


### PR DESCRIPTION
The main changes are
- suppressed exception output when a required command-line option is missing
- Javadoc output is temporary if the -J-d option is not specified.