### PR TITLE
Fix bug #13 and add tests

### DIFF
--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -68,15 +68,11 @@ public class ConditionTranslator {
    * @return a list of {@code PropositionSeries} objects, one for each sentence in the comment
    */
   private static List<PropositionSeries> getPropositionSeries(String comment) {
-
     comment = addPlaceholders(comment);
-
     List<PropositionSeries> result = new ArrayList<>();
-
     for (SemanticGraph semanticGraph : StanfordParser.getSemanticGraphs(comment)) {
       result.add(new SentenceParser(semanticGraph).getPropositionSeries());
     }
-
     return removePlaceholders(result);
   }
 
@@ -135,18 +131,14 @@ public class ConditionTranslator {
    * @return the throws tag string ready to be parsed
    */
   private static String inCorrectFormat(String text) {
-
     java.util.regex.Matcher matcher = Pattern.compile(INEQUALITY_REGEX).matcher(text);
-
     java.util.regex.Matcher matcher1 = Pattern.compile(INEQ_1).matcher(text);
     java.util.regex.Matcher matcher2 = Pattern.compile(INEQ_2).matcher(text);
     java.util.regex.Matcher matcher3 = Pattern.compile(INEQ_3).matcher(text);
     java.util.regex.Matcher matcher4 = Pattern.compile(INEQ_4).matcher(text);
 
     String placeholderText = text;
-
     int i = 0;
-
     List<String> symbols = new ArrayList<>();
     while (matcher.find()) {
       if (matcher4.find()) {
@@ -170,12 +162,9 @@ public class ConditionTranslator {
     }
 
     int j = 0;
-
     java.util.regex.Matcher matcherPlaceHolderPrefix =
         Pattern.compile(PLACEHOLDER_PREFIX + ".").matcher(placeholderText);
-
     while (matcherPlaceHolderPrefix.find()) {
-
       placeholderText = placeholderText.replaceFirst(PLACEHOLDER_PREFIX + ".", symbols.get(j++));
     }
 

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -108,7 +108,7 @@ public class ConditionTranslator {
       placeholderText =
           placeholderText.replaceFirst(INEQUALITY_NUMBER_REGEX, PLACEHOLDER_PREFIX + i++);
     }
-   
+
     return placeholderText;
   }
 
@@ -121,10 +121,10 @@ public class ConditionTranslator {
   private static final String INEQUALITY_REGEX = "(([<>=]=?)|(!=))";
 
   /** Possibilities for the four combinations corresponding to the comparators*/
-  private static final String INEQ_1 = ".(([<>=]=?)|(!=)).";
-  private static final String INEQ_2 = " (([<>=]=?)|(!=)).";
-  private static final String INEQ_3 = ".(([<>=]=?)|(!=)) ";
-  private static final String INEQ_4 = " (([<>=]=?)|(!=)) ";
+  private static final String INEQ_1 = ".(([<>=]=?)|(!=)).";// e.g "b<1"
+  private static final String INEQ_2 = " (([<>=]=?)|(!=)).";// e.g "b <1"
+  private static final String INEQ_3 = ".(([<>=]=?)|(!=)) ";// e.g "b< 1"
+  private static final String INEQ_4 = " (([<>=]=?)|(!=)) ";// e.g "b < 1"
 
   /**
    *

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -121,10 +121,10 @@ public class ConditionTranslator {
   private static final String INEQUALITY_REGEX = "(([<>=]=?)|(!=))";
 
   /** Possibilities for the four combinations corresponding to the comparators*/
-  private static final String INEQ_1 = ".(([<>=]=?)|(!=)).";// e.g "b<1"
-  private static final String INEQ_2 = " (([<>=]=?)|(!=)).";// e.g "b <1"
-  private static final String INEQ_3 = ".(([<>=]=?)|(!=)) ";// e.g "b< 1"
-  private static final String INEQ_4 = " (([<>=]=?)|(!=)) ";// e.g "b < 1"
+  private static final String INEQ_1 = ".(([<>=]=?)|(!=))."; // e.g "b<1"
+  private static final String INEQ_2 = " (([<>=]=?)|(!=))."; // e.g "b <1"
+  private static final String INEQ_3 = ".(([<>=]=?)|(!=)) "; // e.g "b< 1"
+  private static final String INEQ_4 = " (([<>=]=?)|(!=)) "; // e.g "b < 1"
 
   /**
    *

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -108,7 +108,7 @@ public class ConditionTranslator {
       placeholderText =
           placeholderText.replaceFirst(INEQUALITY_NUMBER_REGEX, PLACEHOLDER_PREFIX + i++);
     }
-
+   
     return placeholderText;
   }
 
@@ -142,8 +142,6 @@ public class ConditionTranslator {
     java.util.regex.Matcher matcher2 = Pattern.compile(INEQ_2).matcher(text);
     java.util.regex.Matcher matcher3 = Pattern.compile(INEQ_3).matcher(text);
     java.util.regex.Matcher matcher4 = Pattern.compile(INEQ_4).matcher(text);
-    java.util.regex.Matcher matcherPlaceHolderPrefix =
-        Pattern.compile(PLACEHOLDER_PREFIX).matcher(text);
 
     String placeholderText = text;
 
@@ -163,6 +161,7 @@ public class ConditionTranslator {
         symbols.add(text.substring(matcher.start(), matcher.end()));
         placeholderText =
             placeholderText.replaceFirst(INEQUALITY_REGEX, "is " + PLACEHOLDER_PREFIX + i++ + " ");
+
       } else if (matcher1.find()) {
         symbols.add(text.substring(matcher.start(), matcher.end()));
         placeholderText =
@@ -171,12 +170,15 @@ public class ConditionTranslator {
     }
 
     int j = 0;
+
+    java.util.regex.Matcher matcherPlaceHolderPrefix =
+        Pattern.compile(PLACEHOLDER_PREFIX + ".").matcher(placeholderText);
+
     while (matcherPlaceHolderPrefix.find()) {
 
-      placeholderText = placeholderText.replaceFirst(PLACEHOLDER_PREFIX, symbols.get(j++));
+      placeholderText = placeholderText.replaceFirst(PLACEHOLDER_PREFIX + ".", symbols.get(j++));
     }
 
-    System.out.println(placeholderText);
     return placeholderText;
   }
 

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.toradocu.extractor.DocumentedMethod;
@@ -69,7 +68,9 @@ public class ConditionTranslator {
    * @return a list of {@code PropositionSeries} objects, one for each sentence in the comment
    */
   private static List<PropositionSeries> getPropositionSeries(String comment) {
+
     comment = addPlaceholders(comment);
+
     List<PropositionSeries> result = new ArrayList<>();
 
     for (SemanticGraph semanticGraph : StanfordParser.getSemanticGraphs(comment)) {
@@ -88,20 +89,26 @@ public class ConditionTranslator {
    */
   private static String addPlaceholders(String text) {
     // Replace written out inequalities with symbols.
+
+    text = inCorrectFormat(text);
+
     text =
         text.replace("greater than or equal to", ">=")
             .replace("less than or equal to", "<=")
             .replace("greater than", ">")
             .replace("less than", "<")
             .replace("equal to", "==");
+
     java.util.regex.Matcher matcher = Pattern.compile(INEQUALITY_NUMBER_REGEX).matcher(text);
     String placeholderText = text;
+
     int i = 0;
     while (matcher.find()) {
       inequalities.add(text.substring(matcher.start(), matcher.end()));
       placeholderText =
           placeholderText.replaceFirst(INEQUALITY_NUMBER_REGEX, PLACEHOLDER_PREFIX + i++);
     }
+
     return placeholderText;
   }
 
@@ -109,6 +116,69 @@ public class ConditionTranslator {
   private static final String PLACEHOLDER_PREFIX = "INEQUALITY_";
   /** Stores the inequalities that are replaced by placeholders when addPlaceholders is called. */
   private static List<String> inequalities = new ArrayList<>();
+
+  /** Regular expression just for the comparators*/
+  private static final String INEQUALITY_REGEX = "(([<>=]=?)|(!=))";
+
+  /** Possibilities for the four combinations corresponding to the comparators*/
+  private static final String INEQ_1 = ".(([<>=]=?)|(!=)).";
+  private static final String INEQ_2 = " (([<>=]=?)|(!=)).";
+  private static final String INEQ_3 = ".(([<>=]=?)|(!=)) ";
+  private static final String INEQ_4 = " (([<>=]=?)|(!=)) ";
+
+  /**
+   *
+   * This auxiliar function is meant to be the one that formats the comments for the StamfordParser
+   * to parse them
+   *
+   * @param text the comment of the throws tag that has to be formated
+   * @return the throws tag string ready to be parsed
+   */
+  private static String inCorrectFormat(String text) {
+
+    java.util.regex.Matcher matcher = Pattern.compile(INEQUALITY_REGEX).matcher(text);
+
+    java.util.regex.Matcher matcher1 = Pattern.compile(INEQ_1).matcher(text);
+    java.util.regex.Matcher matcher2 = Pattern.compile(INEQ_2).matcher(text);
+    java.util.regex.Matcher matcher3 = Pattern.compile(INEQ_3).matcher(text);
+    java.util.regex.Matcher matcher4 = Pattern.compile(INEQ_4).matcher(text);
+    java.util.regex.Matcher matcherPlaceHolderPrefix =
+        Pattern.compile(PLACEHOLDER_PREFIX).matcher(text);
+
+    String placeholderText = text;
+
+    int i = 0;
+
+    List<String> symbols = new ArrayList<>();
+    while (matcher.find()) {
+      if (matcher4.find()) {
+        symbols.add(text.substring(matcher.start(), matcher.end()));
+        placeholderText =
+            placeholderText.replaceFirst(INEQUALITY_REGEX, "is " + PLACEHOLDER_PREFIX + i++);
+      } else if (matcher3.find()) {
+        symbols.add(text.substring(matcher.start(), matcher.end()));
+        placeholderText =
+            placeholderText.replaceFirst(INEQUALITY_REGEX, " is " + PLACEHOLDER_PREFIX + i++);
+      } else if (matcher2.find()) {
+        symbols.add(text.substring(matcher.start(), matcher.end()));
+        placeholderText =
+            placeholderText.replaceFirst(INEQUALITY_REGEX, "is " + PLACEHOLDER_PREFIX + i++ + " ");
+      } else if (matcher1.find()) {
+        symbols.add(text.substring(matcher.start(), matcher.end()));
+        placeholderText =
+            placeholderText.replaceFirst(INEQUALITY_REGEX, " is " + PLACEHOLDER_PREFIX + i++ + " ");
+      }
+    }
+
+    int j = 0;
+    while (matcherPlaceHolderPrefix.find()) {
+
+      placeholderText = placeholderText.replaceFirst(PLACEHOLDER_PREFIX, symbols.get(j++));
+    }
+
+    System.out.println(placeholderText);
+    return placeholderText;
+  }
 
   /**
    * Returns a new list of {@code PropositionSeries} in which any placeholder text has been replaced

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -1,6 +1,7 @@
 package org.toradocu;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.number.IsCloseTo.closeTo;
 import static org.junit.Assert.assertThat;
 
 import org.junit.Test;
@@ -44,5 +45,57 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
     TestCaseStats stats = test("org.apache.commons.math3.analysis.integration.SimpsonIntegrator");
     assertThat(PRECISION_MESSAGE, stats.getPrecision(), is(1.0));
     assertThat(RECALL_MESSAGE, stats.getRecall(), is(1.0));
+  }
+
+  @Test
+  public void stepFunctionTest() throws Exception {
+    TestCaseStats stats = test("org.apache.commons.math3.analysis.function.StepFunction");
+    assertThat(PRECISION_MESSAGE, stats.getPrecision(), is(0.8));
+    assertThat(RECALL_MESSAGE, stats.getRecall(), is(0.8));
+  }
+
+  @Test
+  public void iterativeLegendreGaussIntegratorTest() throws Exception {
+    TestCaseStats stats =
+        test("org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator");
+    assertThat(PRECISION_MESSAGE, stats.getPrecision(), closeTo(0.533, PRECISION));
+    assertThat(RECALL_MESSAGE, stats.getRecall(), closeTo(0.533, PRECISION));
+  }
+
+  @Test
+  public void linearInterpolationTest() throws Exception {
+    TestCaseStats stats =
+        test("org.apache.commons.math3.analysis.interpolation.LinearInterpolator");
+    assertThat(PRECISION_MESSAGE, stats.getPrecision(), is(0.6));
+    assertThat(RECALL_MESSAGE, stats.getRecall(), is(0.6));
+  }
+
+  @Test
+  public void loessInterpolatorTest() throws Exception {
+    TestCaseStats stats = test("org.apache.commons.math3.analysis.interpolation.LoessInterpolator");
+    assertThat(PRECISION_MESSAGE, stats.getPrecision(), closeTo(0.473, PRECISION));
+    assertThat(RECALL_MESSAGE, stats.getRecall(), closeTo(0.473, PRECISION));
+  }
+
+  @Test
+  public void polynomialFunctionNewtonFormTest() throws Exception {
+    TestCaseStats stats =
+        test("org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm");
+    assertThat(PRECISION_MESSAGE, stats.getPrecision(), closeTo(0.818, PRECISION));
+    assertThat(RECALL_MESSAGE, stats.getRecall(), closeTo(0.818, PRECISION));
+  }
+
+  @Test
+  public void binaryMutationTest() throws Exception {
+    TestCaseStats stats = test("org.apache.commons.math3.genetics.BinaryMutation");
+    assertThat(PRECISION_MESSAGE, stats.getPrecision(), is(0.5));
+    assertThat(RECALL_MESSAGE, stats.getRecall(), is(0.5));
+  }
+
+  @Test
+  public void cycleCrossoverTest() throws Exception {
+    TestCaseStats stats = test("org.apache.commons.math3.genetics.CycleCrossover");
+    assertThat(PRECISION_MESSAGE, stats.getPrecision(), is(0.75));
+    assertThat(RECALL_MESSAGE, stats.getRecall(), is(0.75));
   }
 }

--- a/src/test/java/org/toradocu/PrecisionRecallTestSuite.java
+++ b/src/test/java/org/toradocu/PrecisionRecallTestSuite.java
@@ -7,7 +7,7 @@ import org.junit.runners.Suite;
 @Suite.SuiteClasses({
   PrecisionRecallCommonsCollections4.class,
   PrecisionRecallGuava19.class,
-  PrecisionRecallCommonsMath3,
+  PrecisionRecallCommonsMath3.class,
   PrecisionRecallJGraphT.class
 })
 public class PrecisionRecallTestSuite {}

--- a/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.function.StepFunction_expected.json
+++ b/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.function.StepFunction_expected.json
@@ -1,0 +1,114 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.function.StepFunction",
+      "name": "StepFunction",
+      "isArray": false
+    },
+    "name": "StepFunction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "x"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "y"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NonMonotonicSequenceException",
+          "name": "NonMonotonicSequenceException",
+          "isArray": false
+        },
+        "comment": "if the x array is not sorted in strictly increasing order.",
+        "condition": "MathArrays.checkOrder(args[0])==false"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if x or y are null.",
+        "condition": "args[0]==null || args[1]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NoDataException",
+          "name": "NoDataException",
+          "isArray": false
+        },
+        "comment": "if x or y are zero-length.",
+        "condition": "args[0].length==0 || args[1].length==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if x and y do not have the same length.",
+        "condition": "((args[0].length) == (args[1].length)) == false"
+      }
+    ],
+    "signature": "StepFunction(double[] x,double[] y)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.function.StepFunction",
+      "name": "StepFunction",
+      "isArray": false
+    },
+    "name": "value",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "x"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "when the activated method itself can ascertain that a precondition, specified in the API expressed at the level of the activated method, has been violated. When Commons Math throws an IllegalArgumentException, it is usually the consequence of checking the actual parameters passed to the method.",
+        "condition": ""
+      }
+    ],
+    "signature": "value(double x)"
+  }
+]

--- a/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator_expected.json
+++ b/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator_expected.json
@@ -1,0 +1,594 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator",
+      "name": "IterativeLegendreGaussIntegrator",
+      "isArray": false
+    },
+    "name": "IterativeLegendreGaussIntegrator",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "n"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "relativeAccuracy"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "absoluteAccuracy"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "minimalIterationCount"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maximalIterationCount"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotStrictlyPositiveException",
+          "name": "NotStrictlyPositiveException",
+          "isArray": false
+        },
+        "comment": "if minimal number of iterations or number of points are not strictly positive.",
+        "condition": "args[0]<=0 || args[3]<=0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NumberIsTooSmallException",
+          "name": "NumberIsTooSmallException",
+          "isArray": false
+        },
+        "comment": "if maximal number of iterations is smaller than or equal to the minimal number of iterations.",
+        "condition": "args[4]<=args[3]"
+      }
+    ],
+    "signature": "IterativeLegendreGaussIntegrator(int n,double relativeAccuracy,double absoluteAccuracy,int minimalIterationCount,int maximalIterationCount)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator",
+      "name": "IterativeLegendreGaussIntegrator",
+      "isArray": false
+    },
+    "name": "IterativeLegendreGaussIntegrator",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "n"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "relativeAccuracy"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "absoluteAccuracy"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotStrictlyPositiveException",
+          "name": "NotStrictlyPositiveException",
+          "isArray": false
+        },
+        "comment": "if n < 1.",
+        "condition": "args[0]<1"
+      }
+    ],
+    "signature": "IterativeLegendreGaussIntegrator(int n,double relativeAccuracy,double absoluteAccuracy)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator",
+      "name": "IterativeLegendreGaussIntegrator",
+      "isArray": false
+    },
+    "name": "IterativeLegendreGaussIntegrator",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "n"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "minimalIterationCount"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maximalIterationCount"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotStrictlyPositiveException",
+          "name": "NotStrictlyPositiveException",
+          "isArray": false
+        },
+        "comment": "if minimal number of iterations is not strictly positive.",
+        "condition": "args[1]<=0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NumberIsTooSmallException",
+          "name": "NumberIsTooSmallException",
+          "isArray": false
+        },
+        "comment": "if maximal number of iterations is smaller than or equal to the minimal number of iterations.",
+        "condition": "args[2]<=args[1]"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotStrictlyPositiveException",
+          "name": "NotStrictlyPositiveException",
+          "isArray": false
+        },
+        "comment": "if n < 1.",
+        "condition": "args[0]<1"
+      }
+    ],
+    "signature": "IterativeLegendreGaussIntegrator(int n,int minimalIterationCount,int maximalIterationCount)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator",
+      "name": "IterativeLegendreGaussIntegrator",
+      "isArray": false
+    },
+    "name": "doIntegrate",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "doIntegrate()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator",
+      "name": "IterativeLegendreGaussIntegrator",
+      "isArray": false
+    },
+    "name": "stage",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "n"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.TooManyEvaluationsException",
+          "name": "TooManyEvaluationsException",
+          "isArray": false
+        },
+        "comment": "if the maximum number of evaluations is exceeded.",
+        "condition": ""
+      }
+    ],
+    "signature": "stage(int n)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "getRelativeAccuracy",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getRelativeAccuracy()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "getAbsoluteAccuracy",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getAbsoluteAccuracy()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "getMinimalIterationCount",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getMinimalIterationCount()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "getMaximalIterationCount",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getMaximalIterationCount()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "getEvaluations",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getEvaluations()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "getIterations",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getIterations()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "incrementCount",
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MaxCountExceededException",
+          "name": "MaxCountExceededException",
+          "isArray": false
+        },
+        "comment": "if the number of iterations exceeds the allowed maximum number",
+        "condition": ""
+      }
+    ],
+    "signature": "incrementCount()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "getMin",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getMin()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "getMax",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getMax()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "computeObjectiveValue",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "point"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.TooManyEvaluationsException",
+          "name": "TooManyEvaluationsException",
+          "isArray": false
+        },
+        "comment": "if the maximal number of function evaluations is exceeded.",
+        "condition": ""
+      }
+    ],
+    "signature": "computeObjectiveValue(double point)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "setup",
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxEval"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.analysis.UnivariateFunction",
+          "name": "UnivariateFunction",
+          "isArray": false
+        },
+        "name": "f"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "lower"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "upper"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if f is null.",
+        "condition": "args[1]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if min >= max.",
+        "condition": ""
+      }
+    ],
+    "signature": "setup(int maxEval,org.apache.commons.math3.analysis.UnivariateFunction f,double lower,double upper)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.integration.BaseAbstractUnivariateIntegrator",
+      "name": "BaseAbstractUnivariateIntegrator",
+      "isArray": false
+    },
+    "name": "integrate",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxEval"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.analysis.UnivariateFunction",
+          "name": "UnivariateFunction",
+          "isArray": false
+        },
+        "name": "f"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "lower"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "upper"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.TooManyEvaluationsException",
+          "name": "TooManyEvaluationsException",
+          "isArray": false
+        },
+        "comment": "if the maximum number of function evaluations is exceeded",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MaxCountExceededException",
+          "name": "MaxCountExceededException",
+          "isArray": false
+        },
+        "comment": "if the maximum iteration count is exceeded or the integrator detects convergence problems otherwise",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if min > max or the endpoints do not satisfy the requirements specified by the integrator",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if f is null.",
+        "condition": "args[1]==null"
+      }
+    ],
+    "signature": "integrate(int maxEval,org.apache.commons.math3.analysis.UnivariateFunction f,double lower,double upper)"
+  }
+]

--- a/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.interpolation.LinearInterpolator_expected.json
+++ b/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.interpolation.LinearInterpolator_expected.json
@@ -1,0 +1,92 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LinearInterpolator",
+      "name": "LinearInterpolator",
+      "isArray": false
+    },
+    "name": "interpolate",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialSplineFunction",
+      "name": "PolynomialSplineFunction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "x"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "y"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if x and y have different sizes.",
+        "condition": "(args[0].length==args[1].length) == false"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NonMonotonicSequenceException",
+          "name": "NonMonotonicSequenceException",
+          "isArray": false
+        },
+        "comment": "if x is not sorted in strict increasing order.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NumberIsTooSmallException",
+          "name": "NumberIsTooSmallException",
+          "isArray": false
+        },
+        "comment": "if the size of x is smaller than 2.",
+        "condition": "args[0].length<2"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the arguments violate assumptions made by the interpolation algorithm.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if arrays lengthes do not match",
+        "condition": "(args[0].length==args[1].length) == false"
+      }
+    ],
+    "signature": "interpolate(double[] x,double[] y)"
+  }
+]

--- a/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.interpolation.LoessInterpolator_expected.json
+++ b/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.interpolation.LoessInterpolator_expected.json
@@ -1,0 +1,581 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "LoessInterpolator",
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "LoessInterpolator()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "LoessInterpolator",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "bandwidth"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "robustnessIters"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "LoessInterpolator(double bandwidth,int robustnessIters)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "LoessInterpolator",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "bandwidth"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "robustnessIters"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "accuracy"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.OutOfRangeException",
+          "name": "OutOfRangeException",
+          "isArray": false
+        },
+        "comment": "if bandwidth does not lie in the interval [0,1].",
+        "condition": "args[0]<0 || args[0]>1"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotPositiveException",
+          "name": "NotPositiveException",
+          "isArray": false
+        },
+        "comment": "if robustnessIters is negative.",
+        "condition": "args[1]<0"
+      }
+    ],
+    "signature": "LoessInterpolator(double bandwidth,int robustnessIters,double accuracy)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "interpolate",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialSplineFunction",
+      "name": "PolynomialSplineFunction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "xval"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "yval"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NonMonotonicSequenceException",
+          "name": "NonMonotonicSequenceException",
+          "isArray": false
+        },
+        "comment": "if xval not sorted in strictly increasing order.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if xval and yval have different sizes.",
+        "condition": "(args[0].length==args[1].length) == false"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NoDataException",
+          "name": "NoDataException",
+          "isArray": false
+        },
+        "comment": "if xval or yval has zero size.",
+        "condition": "args[0].length==0 || args[1].length==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotFiniteNumberException",
+          "name": "NotFiniteNumberException",
+          "isArray": false
+        },
+        "comment": "if any of the arguments and values are not finite real numbers.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NumberIsTooSmallException",
+          "name": "NumberIsTooSmallException",
+          "isArray": false
+        },
+        "comment": "if the bandwidth is too small to accomodate the size of the input data (i.e. the bandwidth must be larger than 2/n).",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the arguments violate assumptions made by the interpolation algorithm.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if arrays lengthes do not match",
+        "condition": "(args[0].length==args[1].length) == false"
+      }
+    ],
+    "signature": "interpolate(double[] xval,double[] yval)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "smooth",
+    "returnType": {
+      "qualifiedName": "double[]",
+      "name": "double[]",
+      "isArray": true,
+      "componentType": {
+        "qualifiedName": "double",
+        "name": "double",
+        "isArray": false
+      }
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "xval"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "yval"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "weights"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NonMonotonicSequenceException",
+          "name": "NonMonotonicSequenceException",
+          "isArray": false
+        },
+        "comment": "if xval not sorted in strictly increasing order.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if xval and yval have different sizes.",
+        "condition": "(args[0].length==args[1].length) == false"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NoDataException",
+          "name": "NoDataException",
+          "isArray": false
+        },
+        "comment": "if xval or yval has zero size.",
+        "condition": "args[0].length==0 || args[1].length==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotFiniteNumberException",
+          "name": "NotFiniteNumberException",
+          "isArray": false
+        },
+        "comment": "if any of the arguments and values are not finite real numbers.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NumberIsTooSmallException",
+          "name": "NumberIsTooSmallException",
+          "isArray": false
+        },
+        "comment": "if the bandwidth is too small to accomodate the size of the input data (i.e. the bandwidth must be larger than 2/n).",
+        "condition": ""
+      }
+    ],
+    "signature": "smooth(double[] xval,double[] yval,double[] weights)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "smooth",
+    "returnType": {
+      "qualifiedName": "double[]",
+      "name": "double[]",
+      "isArray": true,
+      "componentType": {
+        "qualifiedName": "double",
+        "name": "double",
+        "isArray": false
+      }
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "xval"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "yval"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NonMonotonicSequenceException",
+          "name": "NonMonotonicSequenceException",
+          "isArray": false
+        },
+        "comment": "if xval not sorted in strictly increasing order.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if xval and yval have different sizes.",
+        "condition": "(args[0].length==args[1].length) == false"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NoDataException",
+          "name": "NoDataException",
+          "isArray": false
+        },
+        "comment": "if xval or yval has zero size.",
+        "condition": "args[0].length==0 || args[1].length==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotFiniteNumberException",
+          "name": "NotFiniteNumberException",
+          "isArray": false
+        },
+        "comment": "if any of the arguments and values are not finite real numbers.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NumberIsTooSmallException",
+          "name": "NumberIsTooSmallException",
+          "isArray": false
+        },
+        "comment": "if the bandwidth is too small to accomodate the size of the input data (i.e. the bandwidth must be larger than 2/n).",
+        "condition": ""
+      }
+    ],
+    "signature": "smooth(double[] xval,double[] yval)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "updateBandwidthInterval",
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "xval"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "weights"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      },
+      {
+        "type": {
+          "qualifiedName": "int[]",
+          "name": "int[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "int",
+            "name": "int",
+            "isArray": false
+          }
+        },
+        "name": "bandwidthInterval"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "updateBandwidthInterval(double[] xval,double[] weights,int i,int[] bandwidthInterval)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "nextNonzero",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "weights"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "nextNonzero(double[] weights,int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "tricube",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "x"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "tricube(double x)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.interpolation.LoessInterpolator",
+      "name": "LoessInterpolator",
+      "isArray": false
+    },
+    "name": "checkAllFiniteReal",
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "values"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NotFiniteNumberException",
+          "name": "NotFiniteNumberException",
+          "isArray": false
+        },
+        "comment": "if one of the values is not a finite real number.",
+        "condition": ""
+      }
+    ],
+    "signature": "checkAllFiniteReal(double[] values)"
+  }
+]

--- a/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm_expected.json
+++ b/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm_expected.json
@@ -1,0 +1,393 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "PolynomialFunctionNewtonForm",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "a"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "c"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if any argument is null.",
+        "condition": "args[0]==null || args[1]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NoDataException",
+          "name": "NoDataException",
+          "isArray": false
+        },
+        "comment": "if any array has zero length.",
+	"condition": "args[0].length==0 || args[1].length==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if the size difference between a and c is not equal to 1.",
+        "condition": "((args[0].length - args[1].length) == 1) == false"
+      }
+    ],
+    "signature": "PolynomialFunctionNewtonForm(double[] a,double[] c)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "value",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "z"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "when the activated method itself can ascertain that a precondition, specified in the API expressed at the level of the activated method, has been violated. When Commons Math throws an IllegalArgumentException, it is usually the consequence of checking the actual parameters passed to the method.",
+        "condition": ""
+      }
+    ],
+    "signature": "value(double z)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "value",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.analysis.differentiation.DerivativeStructure",
+      "name": "DerivativeStructure",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.analysis.differentiation.DerivativeStructure",
+          "name": "DerivativeStructure",
+          "isArray": false
+        },
+        "name": "t"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if t is inconsistent with the function's free parameters or order",
+        "condition": ""
+      }
+    ],
+    "signature": "value(org.apache.commons.math3.analysis.differentiation.DerivativeStructure t)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "degree",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "degree()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "getNewtonCoefficients",
+    "returnType": {
+      "qualifiedName": "double[]",
+      "name": "double[]",
+      "isArray": true,
+      "componentType": {
+        "qualifiedName": "double",
+        "name": "double",
+        "isArray": false
+      }
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNewtonCoefficients()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "getCenters",
+    "returnType": {
+      "qualifiedName": "double[]",
+      "name": "double[]",
+      "isArray": true,
+      "componentType": {
+        "qualifiedName": "double",
+        "name": "double",
+        "isArray": false
+      }
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getCenters()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "getCoefficients",
+    "returnType": {
+      "qualifiedName": "double[]",
+      "name": "double[]",
+      "isArray": true,
+      "componentType": {
+        "qualifiedName": "double",
+        "name": "double",
+        "isArray": false
+      }
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getCoefficients()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "evaluate",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "a"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "c"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "z"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if any argument is null.",
+        "condition": "args[0]==null || args[1]==null || args[2]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NoDataException",
+          "name": "NoDataException",
+          "isArray": false
+        },
+        "comment": "if any array has zero length.",
+        "condition": "args[0].length==0 || args[1].length==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if the size difference between a and c is not equal to 1.",
+        "condition": "((args[0].lenght - args[1].length)==1) == false"
+      }
+    ],
+    "signature": "evaluate(double[] a,double[] c,double z)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "computeCoefficients",
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "computeCoefficients()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.analysis.polynomials.PolynomialFunctionNewtonForm",
+      "name": "PolynomialFunctionNewtonForm",
+      "isArray": false
+    },
+    "name": "verifyInputArray",
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "a"
+      },
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "c"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if any argument is null.",
+        "condition": "args[0]==null || args[1]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NoDataException",
+          "name": "NoDataException",
+          "isArray": false
+        },
+        "comment": "if any array has zero length.",
+        "condition": "args[0].length==0 || args[1].length==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if the size difference between a and c is not equal to 1.",
+        "condition": "((args[0].length - args[1].length)==1) == false"
+      }
+    ],
+    "signature": "verifyInputArray(double[] a,double[] c)"
+  }
+]

--- a/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.genetics.BinaryMutation_expected.json
+++ b/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.genetics.BinaryMutation_expected.json
@@ -1,0 +1,47 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.genetics.BinaryMutation",
+      "name": "BinaryMutation",
+      "isArray": false
+    },
+    "name": "mutate",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.genetics.Chromosome",
+      "name": "Chromosome",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.genetics.Chromosome",
+          "name": "Chromosome",
+          "isArray": false
+        },
+        "name": "original"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if original is not an instance of BinaryChromosome.",
+        "condition": "(args[0] instanceof BinaryChromosome) == false"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the given chromosome is not compatible with this MutationPolicy",
+        "condition": ""
+      }
+    ],
+    "signature": "mutate(org.apache.commons.math3.genetics.Chromosome original)"
+  }
+]

--- a/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.genetics.CycleCrossover_expected.json
+++ b/src/test/resources/CommonsMath-3.6.1/org.apache.commons.math3.genetics.CycleCrossover_expected.json
@@ -1,0 +1,158 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.genetics.CycleCrossover",
+      "name": "CycleCrossover",
+      "isArray": false
+    },
+    "name": "CycleCrossover",
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "CycleCrossover()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.genetics.CycleCrossover",
+      "name": "CycleCrossover",
+      "isArray": false
+    },
+    "name": "CycleCrossover",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "boolean",
+          "name": "boolean",
+          "isArray": false
+        },
+        "name": "randomStart"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "CycleCrossover(boolean randomStart)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.genetics.CycleCrossover",
+      "name": "CycleCrossover",
+      "isArray": false
+    },
+    "name": "isRandomStart",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "isRandomStart()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.genetics.CycleCrossover",
+      "name": "CycleCrossover",
+      "isArray": false
+    },
+    "name": "crossover",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.genetics.ChromosomePair",
+      "name": "ChromosomePair",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.genetics.Chromosome",
+          "name": "Chromosome",
+          "isArray": false
+        },
+        "name": "first"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.genetics.Chromosome",
+          "name": "Chromosome",
+          "isArray": false
+        },
+        "name": "second"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the chromosomes are not an instance of AbstractListChromosome",
+        "condition": "(args[0] instanceof AbstractListChromosome) == false || (args[1] insatnceof AbstractListChromosome) == false"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if the length of the two chromosomes is different",
+        "condition": "(args[0].getLength() == args[1].getLength()) == false"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the given chromosomes are not compatible with this CrossoverPolicy",
+        "condition": ""
+      }
+    ],
+    "signature": "crossover(org.apache.commons.math3.genetics.Chromosome first,org.apache.commons.math3.genetics.Chromosome second)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.genetics.CycleCrossover",
+      "name": "CycleCrossover",
+      "isArray": false
+    },
+    "name": "mate",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.genetics.ChromosomePair",
+      "name": "ChromosomePair",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.genetics.AbstractListChromosome",
+          "name": "AbstractListChromosome",
+          "isArray": false
+        },
+        "name": "first"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.genetics.AbstractListChromosome",
+          "name": "AbstractListChromosome",
+          "isArray": false
+        },
+        "name": "second"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if the length of the two chromosomes is different",
+        "condition": "(args[0].getLength() == args[1].getLength()) == false"
+      }
+    ],
+    "signature": "mate(org.apache.commons.math3.genetics.AbstractListChromosome first,org.apache.commons.math3.genetics.AbstractListChromosome second)"
+  }
+]


### PR DESCRIPTION
I've fixed the boolean-like throws comments for the more-than-one-length variables.

So, the PrecisionRecall test for the CommonsMath3 has the Gaussian test passed 

=== Test org.apache.commons.math3.analysis.function.Gaussian ===
org.apache.commons.math3.analysis.function.Gaussian | # Conditions: 4 | Precision: 1.00 | Recall: 1.00

and also the Logistic class too

=== Test org.apache.commons.math3.analysis.function.Logistic ===
org.apache.commons.math3.analysis.function.Logistic | # Conditions: 3 | Precision: 1.00 | Recall: 1.00

I've just added a inCorrectFormat method, that adds the verb to the phrase and keeps the symbol. then, it follows the rest of the addPlaceHolderText method.