### PR TITLE
Added classes to CommonsMath3's PrecisionRecall test and added direct translations

### DIFF
--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -96,7 +96,7 @@ public class ConditionTranslator {
             .replace("less than or equal to", "<=")
             .replace("greater than", ">")
             .replace("smaller than or equal to", "<=")
-            .replace("smaller than", "<")            
+            .replace("smaller than", "<")
             .replace("less than", "<")
             .replace("equal to", "==");
 

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -96,7 +96,7 @@ public class ConditionTranslator {
             .replace("less than or equal to", "<=")
             .replace("greater than", ">")
             .replace("smaller than", "<")
-            .replaceAll("smaller than or equal to", "<=")
+            .replace("smaller than or equal to", "<=")
             .replace("less than", "<")
             .replace("equal to", "==");
 

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -95,8 +95,8 @@ public class ConditionTranslator {
         text.replace("greater than or equal to", ">=")
             .replace("less than or equal to", "<=")
             .replace("greater than", ">")
-            .replace("smaller than", "<")
             .replace("smaller than or equal to", "<=")
+            .replace("smaller than", "<")            
             .replace("less than", "<")
             .replace("equal to", "==");
 

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -95,6 +95,8 @@ public class ConditionTranslator {
         text.replace("greater than or equal to", ">=")
             .replace("less than or equal to", "<=")
             .replace("greater than", ">")
+            .replace("smaller than", "<")
+            .replaceAll("smaller than or equal to", "<=")
             .replace("less than", "<")
             .replace("equal to", "==");
 

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -285,10 +285,12 @@ public class Matcher {
    */
   private static String simpleMatch(String predicate) {
     java.util.regex.Matcher isWord =
-        Pattern.compile("(is |are )?(==|=)? ??(true|false|null|zero|positive|strictly positive|negative|strictly negative)")
+        Pattern.compile(
+                "(is |are )?(==|=)? ??(true|false|null|zero|positive|strictly positive|negative|strictly negative)")
             .matcher(predicate);
     java.util.regex.Matcher isNotWord =
-        Pattern.compile("(is |are )?(!=) ?(true|false|null|zero|positive|strictly positive|negative|strictly negative)")
+        Pattern.compile(
+                "(is |are )?(!=) ?(true|false|null|zero|positive|strictly positive|negative|strictly negative)")
             .matcher(predicate);
     java.util.regex.Matcher numberRelation =
         Pattern.compile("(is |are )?(<=|>=|<|>|!=|==|=)? ?(-?[0-9]+)").matcher(predicate);

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -285,10 +285,10 @@ public class Matcher {
    */
   private static String simpleMatch(String predicate) {
     java.util.regex.Matcher isWord =
-        Pattern.compile("(is |are )?(==|=)? ?(true|false|null|zero|positive|negative)")
+        Pattern.compile("(is |are )?(==|=)? ??(true|false|null|zero|positive|strictly positive|negative|strictly negative)")
             .matcher(predicate);
     java.util.regex.Matcher isNotWord =
-        Pattern.compile("(is |are )?(!=) ?(true|false|null|zero|positive|negative)")
+        Pattern.compile("(is |are )?(!=) ?(true|false|null|zero|positive|strictly positive|negative|strictly negative)")
             .matcher(predicate);
     java.util.regex.Matcher numberRelation =
         Pattern.compile("(is |are )?(<=|>=|<|>|!=|==|=)? ?(-?[0-9]+)").matcher(predicate);
@@ -300,7 +300,7 @@ public class Matcher {
         return "==" + word;
       } else if (word.equals("zero")) {
         return "==0";
-      } else if (word.equals("positive")) {
+      } else if (word.equals("positive") || word.equals("strictly positive")) {
         return ">0";
       } else { // negative
         return "<0";
@@ -311,7 +311,7 @@ public class Matcher {
         return "!=" + word;
       } else if (word.equals("zero")) {
         return "!=0";
-      } else if (word.equals("positive")) {
+      } else if (word.equals("positive") || word.equals("strictly positive")) {
         return "<0";
       } else { // not negative
         return ">=0";

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -51,7 +51,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void linearInterpolatorTest() throws Exception {
-    test("org.apache.commons.math3.analysis.interpolation.LinearInterpolator", 1.0, 0.4);
+    test("org.apache.commons.math3.analysis.interpolation.LinearInterpolator", 0.666, 0.4);
   }
 
   @Test
@@ -77,7 +77,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
   
   @Test
   public void bigFractionTest() throws Exception {
-    test("org.apache.commons.math3.fraction.BigFraction", 0.740, 1.0);
+    test("org.apache.commons.math3.fraction.BigFraction", 0.791, 0.703);
   }
   
   @Test
@@ -87,21 +87,21 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
   
   @Test
   public void lineTest() throws Exception {
-    test("org.apache.commons.math3.geometry.euclidean.threed.Line", 0.0, 1.0);
+    test("org.apache.commons.math3.geometry.euclidean.threed.Line", 0.0, 0.0);
   }
   
   @Test
   public void subLineTest() throws Exception {
-    test("org.apache.commons.math3.geometry.euclidean.threed.SubLine", 0.25, 1.0);
+    test("org.apache.commons.math3.geometry.euclidean.threed.SubLine", 1.0, 0.25);
   }
   
   @Test
   public void Vector3DTest() throws Exception {
-    test("org.apache.commons.math3.geometry.euclidean.threed.Vector3D", 0.5, 0.5);
+    test("org.apache.commons.math3.geometry.euclidean.threed.Vector3D", 1.0, 0.5);
   }
   
   @Test
   public void s2PointTest() throws Exception {
-    test("org.apache.commons.math3.geometry.spherical.twod.S2Point", 0.666, 0.333);
+    test("org.apache.commons.math3.geometry.spherical.twod.S2Point", 0.666, 0.666);
   }
 }

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -74,4 +74,34 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
   public void cycleCrossoverTest() throws Exception {
     test("org.apache.commons.math3.genetics.CycleCrossover", 0.5, 0.25);
   }
+  
+  @Test
+  public void bigFractionTest() throws Exception {
+    test("org.apache.commons.math3.fraction.BigFraction", 0.740, 1.0);
+  }
+  
+  @Test
+  public void fractionTest() throws Exception {
+    test("org.apache.commons.math3.fraction.Fraction", 0.9, 1.0);
+  }
+  
+  @Test
+  public void lineTest() throws Exception {
+    test("org.apache.commons.math3.geometry.euclidean.threed.Line", 0.0, 1.0);
+  }
+  
+  @Test
+  public void subLineTest() throws Exception {
+    test("org.apache.commons.math3.geometry.euclidean.threed.SubLine", 0.25, 1.0);
+  }
+  
+  @Test
+  public void Vector3DTest() throws Exception {
+    test("org.apache.commons.math3.geometry.euclidean.threed.Vector3D", 0.5, 0.5);
+  }
+  
+  @Test
+  public void s2PointTest() throws Exception {
+    test("org.apache.commons.math3.geometry.spherical.twod.S2Point", 0.666, 0.333);
+  }
 }

--- a/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.fraction.BigFraction_expected.json
+++ b/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.fraction.BigFraction_expected.json
@@ -1,0 +1,1569 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.math.BigInteger",
+          "name": "BigInteger",
+          "isArray": false
+        },
+        "name": "num"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "BigFraction(java.math.BigInteger num)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.math.BigInteger",
+          "name": "BigInteger",
+          "isArray": false
+        },
+        "name": "num"
+      },
+      {
+        "type": {
+          "qualifiedName": "java.math.BigInteger",
+          "name": "BigInteger",
+          "isArray": false
+        },
+        "name": "den"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.ZeroException",
+          "name": "ZeroException",
+          "isArray": false
+        },
+        "comment": "if the denominator is zero.",
+        "condition": "den.signum()==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if either of the arguments is null",
+        "condition": "args[0]==null || args[1]==null"
+      }
+    ],
+    "signature": "BigFraction(java.math.BigInteger num,java.math.BigInteger den)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "value"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if value is NaN or infinite",
+        "condition": "Double.isNaN(args[0]) || Double.isInfinite(args[0])"
+      }
+    ],
+    "signature": "BigFraction(double value)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "value"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "epsilon"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxIterations"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.fraction.FractionConversionException",
+          "name": "FractionConversionException",
+          "isArray": false
+        },
+        "comment": "if the continued fraction failed to converge.",
+        "condition": ""
+      }
+    ],
+    "signature": "BigFraction(double value,double epsilon,int maxIterations)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "value"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "epsilon"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxDenominator"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxIterations"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.fraction.FractionConversionException",
+          "name": "FractionConversionException",
+          "isArray": false
+        },
+        "comment": "if the continued fraction failed to converge.",
+        "condition": ""
+      }
+    ],
+    "signature": "BigFraction(double value,double epsilon,int maxDenominator,int maxIterations)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "value"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxDenominator"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.fraction.FractionConversionException",
+          "name": "FractionConversionException",
+          "isArray": false
+        },
+        "comment": "if the continued fraction failed to converge.",
+        "condition": ""
+      }
+    ],
+    "signature": "BigFraction(double value,int maxDenominator)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "num"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "BigFraction(int num)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "num"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "den"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "BigFraction(int num,int den)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "num"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "BigFraction(long num)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "BigFraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "num"
+      },
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "den"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "BigFraction(long num,long den)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "getReducedFraction",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "numerator"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "denominator"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.ArithmeticException",
+          "name": "ArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the denominator is zero.",
+        "condition": "args[1]==0"
+      }
+    ],
+    "signature": "getReducedFraction(int numerator,int denominator)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "abs",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "abs()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "add",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.math.BigInteger",
+          "name": "BigInteger",
+          "isArray": false
+        },
+        "name": "bg"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the BigInteger is null.",
+        "condition": "args[0]==null"
+      }
+    ],
+    "signature": "add(java.math.BigInteger bg)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "add",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "add(int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "add",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "l"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "add(long l)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "add",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+          "name": "BigFraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the BigFraction is null.",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if a is null.",
+        "condition": "target.abs()==null"
+      }
+    ],
+    "signature": "add(org.apache.commons.math3.fraction.BigFraction fraction)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "bigDecimalValue",
+    "returnType": {
+      "qualifiedName": "java.math.BigDecimal",
+      "name": "BigDecimal",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.ArithmeticException",
+          "name": "ArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the exact quotient does not have a terminating decimal expansion.",
+        "condition": ""
+      }
+    ],
+    "signature": "bigDecimalValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "bigDecimalValue",
+    "returnType": {
+      "qualifiedName": "java.math.BigDecimal",
+      "name": "BigDecimal",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "roundingMode"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if roundingMode does not represent a valid rounding mode.",
+        "condition": ""
+      }
+    ],
+    "signature": "bigDecimalValue(int roundingMode)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "bigDecimalValue",
+    "returnType": {
+      "qualifiedName": "java.math.BigDecimal",
+      "name": "BigDecimal",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "scale"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "roundingMode"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "bigDecimalValue(int scale,int roundingMode)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "compareTo",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+          "name": "BigFraction",
+          "isArray": false
+        },
+        "name": "object"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "compareTo(org.apache.commons.math3.fraction.BigFraction object)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "divide",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.math.BigInteger",
+          "name": "BigInteger",
+          "isArray": false
+        },
+        "name": "bg"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the BigInteger is null",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the fraction to divide by is zero",
+        "condition": "args[0].signum()==0"
+      }
+    ],
+    "signature": "divide(java.math.BigInteger bg)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "divide",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the fraction to divide by is zero",
+        "condition": "args[0]==0"
+      }
+    ],
+    "signature": "divide(int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "divide",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "l"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the fraction to divide by is zero",
+        "condition": "args[0]==0"
+      }
+    ],
+    "signature": "divide(long l)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "divide",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+          "name": "BigFraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the fraction is null.",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the fraction to divide by is zero",
+        "condition": "args[0].numerator.signum()==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if a is null.",
+        "condition": "target.abs()==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if a is zero",
+        "condition": "target.abs()==0"
+      }
+    ],
+    "signature": "divide(org.apache.commons.math3.fraction.BigFraction fraction)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "doubleValue",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "doubleValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "equals",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "other"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "equals(java.lang.Object other)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "floatValue",
+    "returnType": {
+      "qualifiedName": "float",
+      "name": "float",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "floatValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "getDenominator",
+    "returnType": {
+      "qualifiedName": "java.math.BigInteger",
+      "name": "BigInteger",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getDenominator()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "getDenominatorAsInt",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getDenominatorAsInt()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "getDenominatorAsLong",
+    "returnType": {
+      "qualifiedName": "long",
+      "name": "long",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getDenominatorAsLong()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "getNumerator",
+    "returnType": {
+      "qualifiedName": "java.math.BigInteger",
+      "name": "BigInteger",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNumerator()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "getNumeratorAsInt",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNumeratorAsInt()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "getNumeratorAsLong",
+    "returnType": {
+      "qualifiedName": "long",
+      "name": "long",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNumeratorAsLong()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "hashCode",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "hashCode()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "intValue",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "intValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "longValue",
+    "returnType": {
+      "qualifiedName": "long",
+      "name": "long",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "longValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "multiply",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.math.BigInteger",
+          "name": "BigInteger",
+          "isArray": false
+        },
+        "name": "bg"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if bg is null.",
+        "condition": "args[0]==null"
+      }
+    ],
+    "signature": "multiply(java.math.BigInteger bg)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "multiply",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "multiply(int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "multiply",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "l"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "multiply(long l)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "multiply",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+          "name": "BigFraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if fraction is null.",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if a is null.",
+        "condition": "target.abs()==null"
+      }
+    ],
+    "signature": "multiply(org.apache.commons.math3.fraction.BigFraction fraction)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "negate",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "negate()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "percentageValue",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "percentageValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "pow",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "exponent"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "pow(int exponent)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "pow",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "exponent"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "pow(long exponent)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "pow",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.math.BigInteger",
+          "name": "BigInteger",
+          "isArray": false
+        },
+        "name": "exponent"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "pow(java.math.BigInteger exponent)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "pow",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "exponent"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "pow(double exponent)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "reciprocal",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if this is zero",
+        "condition": "this.intValue()==0"
+      }
+    ],
+    "signature": "reciprocal()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "reduce",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "reduce()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "subtract",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.math.BigInteger",
+          "name": "BigInteger",
+          "isArray": false
+        },
+        "name": "bg"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the BigInteger is null.",
+        "condition": "args[0]==null"
+      }
+    ],
+    "signature": "subtract(java.math.BigInteger bg)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "subtract",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "subtract(int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "subtract",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "l"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "subtract(long l)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "subtract",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+          "name": "BigFraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the fraction is null.",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if a is null.",
+        "condition": "target.abs()==null"
+      }
+    ],
+    "signature": "subtract(org.apache.commons.math3.fraction.BigFraction fraction)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "toString",
+    "returnType": {
+      "qualifiedName": "java.lang.String",
+      "name": "String",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toString()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFraction",
+      "name": "BigFraction",
+      "isArray": false
+    },
+    "name": "getField",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.BigFractionField",
+      "name": "BigFractionField",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getField()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "java.lang.Number",
+      "name": "Number",
+      "isArray": false
+    },
+    "name": "byteValue",
+    "returnType": {
+      "qualifiedName": "byte",
+      "name": "byte",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "byteValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "java.lang.Number",
+      "name": "Number",
+      "isArray": false
+    },
+    "name": "shortValue",
+    "returnType": {
+      "qualifiedName": "short",
+      "name": "short",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "shortValue()"
+  }
+]

--- a/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.fraction.Fraction_expected.json
+++ b/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.fraction.Fraction_expected.json
@@ -1,0 +1,986 @@
+
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "Fraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "value"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.fraction.FractionConversionException",
+          "name": "FractionConversionException",
+          "isArray": false
+        },
+        "comment": "if the continued fraction failed to converge.",
+        "condition": ""
+      }
+    ],
+    "signature": "Fraction(double value)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "Fraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "value"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "epsilon"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxIterations"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.fraction.FractionConversionException",
+          "name": "FractionConversionException",
+          "isArray": false
+        },
+        "comment": "if the continued fraction failed to converge.",
+        "condition": ""
+      }
+    ],
+    "signature": "Fraction(double value,double epsilon,int maxIterations)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "Fraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "value"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxDenominator"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.fraction.FractionConversionException",
+          "name": "FractionConversionException",
+          "isArray": false
+        },
+        "comment": "if the continued fraction failed to converge",
+        "condition": ""
+      }
+    ],
+    "signature": "Fraction(double value,int maxDenominator)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "Fraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "value"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "epsilon"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxDenominator"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "maxIterations"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.fraction.FractionConversionException",
+          "name": "FractionConversionException",
+          "isArray": false
+        },
+        "comment": "if the continued fraction failed to converge.",
+        "condition": ""
+      }
+    ],
+    "signature": "Fraction(double value,double epsilon,int maxDenominator,int maxIterations)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "Fraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "num"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "Fraction(int num)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "Fraction",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "num"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "den"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the denominator is zero",
+        "condition": "args[1]==0"
+      }
+    ],
+    "signature": "Fraction(int num,int den)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "abs",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "abs()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "compareTo",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+          "name": "Fraction",
+          "isArray": false
+        },
+        "name": "object"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "compareTo(org.apache.commons.math3.fraction.Fraction object)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "doubleValue",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "doubleValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "equals",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "other"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "equals(java.lang.Object other)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "floatValue",
+    "returnType": {
+      "qualifiedName": "float",
+      "name": "float",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "floatValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "getDenominator",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getDenominator()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "getNumerator",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNumerator()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "hashCode",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "hashCode()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "intValue",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "intValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "longValue",
+    "returnType": {
+      "qualifiedName": "long",
+      "name": "long",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "longValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "negate",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "negate()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "reciprocal",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if this is zero",
+        "condition": "this.intValue()==0"
+      }
+    ],
+    "signature": "reciprocal()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "add",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+          "name": "Fraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the fraction is null",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the resulting numerator or denominator exceeds Integer.MAX_VALUE",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if a is null.",
+        "condition": "target.abs()==null"
+      }
+    ],
+    "signature": "add(org.apache.commons.math3.fraction.Fraction fraction)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "add",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "add(int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "subtract",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+          "name": "Fraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the fraction is null",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the resulting numerator or denominator cannot be represented in an int.",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if a is null.",
+        "condition": "target.abs()==null"
+      }
+    ],
+    "signature": "subtract(org.apache.commons.math3.fraction.Fraction fraction)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "subtract",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "subtract(int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "addSub",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+          "name": "Fraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      },
+      {
+        "type": {
+          "qualifiedName": "boolean",
+          "name": "boolean",
+          "isArray": false
+        },
+        "name": "isAdd"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the fraction is null",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the resulting numerator or denominator cannot be represented in an int.",
+        "condition": ""
+      }
+    ],
+    "signature": "addSub(org.apache.commons.math3.fraction.Fraction fraction,boolean isAdd)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "multiply",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+          "name": "Fraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if the fraction is null",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the resulting numerator or denominator exceeds Integer.MAX_VALUE",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if a is null.",
+        "condition": "target.abs()==null"
+      }
+    ],
+    "signature": "multiply(org.apache.commons.math3.fraction.Fraction fraction)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "multiply",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "multiply(int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "divide",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+          "name": "Fraction",
+          "isArray": false
+        },
+        "name": "fraction"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the fraction is null",
+        "condition": "args[0]==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the fraction to divide by is zero",
+        "condition": "args[0].numerator==0"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the resulting numerator or denominator exceeds Integer.MAX_VALUE",
+        "condition": ""
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.NullArgumentException",
+          "name": "NullArgumentException",
+          "isArray": false
+        },
+        "comment": "if a is null.",
+        "condition": "target.abs()==null"
+      },
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if a is zero",
+        "condition": "target.abs()==0"
+      }
+    ],
+    "signature": "divide(org.apache.commons.math3.fraction.Fraction fraction)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "divide",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "i"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "divide(int i)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "percentageValue",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "percentageValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "getReducedFraction",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "numerator"
+      },
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "denominator"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the denominator is zero",
+        "condition": "args[1]==0"
+      }
+    ],
+    "signature": "getReducedFraction(int numerator,int denominator)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "toString",
+    "returnType": {
+      "qualifiedName": "java.lang.String",
+      "name": "String",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toString()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.fraction.Fraction",
+      "name": "Fraction",
+      "isArray": false
+    },
+    "name": "getField",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.fraction.FractionField",
+      "name": "FractionField",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getField()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "java.lang.Number",
+      "name": "Number",
+      "isArray": false
+    },
+    "name": "byteValue",
+    "returnType": {
+      "qualifiedName": "byte",
+      "name": "byte",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "byteValue()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "java.lang.Number",
+      "name": "Number",
+      "isArray": false
+    },
+    "name": "shortValue",
+    "returnType": {
+      "qualifiedName": "short",
+      "name": "short",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "shortValue()"
+  }
+]

--- a/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.Line_expected.json
+++ b/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.Line_expected.json
@@ -1,0 +1,550 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "Line",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "p1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "p2"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "tolerance"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the points are equal",
+        "condition": "args[0].equals(args[1])"
+      }
+    ],
+    "signature": "Line(org.apache.commons.math3.geometry.euclidean.threed.Vector3D p1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D p2,double tolerance)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "Line",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+          "name": "Line",
+          "isArray": false
+        },
+        "name": "line"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "Line(org.apache.commons.math3.geometry.euclidean.threed.Line line)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "Line",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "p1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "p2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the points are equal",
+        "condition": "args[0].equals(args[1])"
+      }
+    ],
+    "signature": "Line(org.apache.commons.math3.geometry.euclidean.threed.Vector3D p1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D p2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "reset",
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "p1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "p2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the points are equal",
+        "condition": "args[0].equals(args[1])"
+      }
+    ],
+    "signature": "reset(org.apache.commons.math3.geometry.euclidean.threed.Vector3D p1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D p2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "getTolerance",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getTolerance()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "revert",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "revert()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "getDirection",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getDirection()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "getOrigin",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getOrigin()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "getAbscissa",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "point"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getAbscissa(org.apache.commons.math3.geometry.euclidean.threed.Vector3D point)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "pointAt",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "abscissa"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "pointAt(double abscissa)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "toSubSpace",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.oned.Vector1D",
+      "name": "Vector1D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "vector"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toSubSpace(org.apache.commons.math3.geometry.Vector vector)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "toSpace",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "vector"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toSpace(org.apache.commons.math3.geometry.Vector vector)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "toSubSpace",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.oned.Vector1D",
+      "name": "Vector1D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Point",
+          "name": "Point",
+          "isArray": false
+        },
+        "name": "point"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toSubSpace(org.apache.commons.math3.geometry.Point point)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "toSpace",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Point",
+          "name": "Point",
+          "isArray": false
+        },
+        "name": "point"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toSpace(org.apache.commons.math3.geometry.Point point)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "isSimilarTo",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+          "name": "Line",
+          "isArray": false
+        },
+        "name": "line"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "isSimilarTo(org.apache.commons.math3.geometry.euclidean.threed.Line line)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "contains",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "p"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "contains(org.apache.commons.math3.geometry.euclidean.threed.Vector3D p)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "distance",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "p"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance(org.apache.commons.math3.geometry.euclidean.threed.Vector3D p)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "distance",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+          "name": "Line",
+          "isArray": false
+        },
+        "name": "line"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance(org.apache.commons.math3.geometry.euclidean.threed.Line line)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "closestPoint",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+          "name": "Line",
+          "isArray": false
+        },
+        "name": "line"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "closestPoint(org.apache.commons.math3.geometry.euclidean.threed.Line line)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "intersection",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+          "name": "Line",
+          "isArray": false
+        },
+        "name": "line"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "intersection(org.apache.commons.math3.geometry.euclidean.threed.Line line)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+      "name": "Line",
+      "isArray": false
+    },
+    "name": "wholeLine",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+      "name": "SubLine",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "wholeLine()"
+  }
+]

--- a/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.SubLine_expected.json
+++ b/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.SubLine_expected.json
@@ -1,0 +1,251 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+      "name": "SubLine",
+      "isArray": false
+    },
+    "name": "SubLine",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Line",
+          "name": "Line",
+          "isArray": false
+        },
+        "name": "line"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.oned.IntervalsSet",
+          "name": "IntervalsSet",
+          "isArray": false
+        },
+        "name": "remainingRegion"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "SubLine(org.apache.commons.math3.geometry.euclidean.threed.Line line,org.apache.commons.math3.geometry.euclidean.oned.IntervalsSet remainingRegion)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+      "name": "SubLine",
+      "isArray": false
+    },
+    "name": "SubLine",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "start"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "end"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "tolerance"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the points are equal",
+        "condition": "args[0].equals(args[1])"
+      }
+    ],
+    "signature": "SubLine(org.apache.commons.math3.geometry.euclidean.threed.Vector3D start,org.apache.commons.math3.geometry.euclidean.threed.Vector3D end,double tolerance)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+      "name": "SubLine",
+      "isArray": false
+    },
+    "name": "SubLine",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "start"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "end"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the points are equal",
+        "condition": "args[0].equals(args[1])"
+      }
+    ],
+    "signature": "SubLine(org.apache.commons.math3.geometry.euclidean.threed.Vector3D start,org.apache.commons.math3.geometry.euclidean.threed.Vector3D end)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+      "name": "SubLine",
+      "isArray": false
+    },
+    "name": "SubLine",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Segment",
+          "name": "Segment",
+          "isArray": false
+        },
+        "name": "segment"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the segment endpoints are equal",
+        "condition": ""
+      }
+    ],
+    "signature": "SubLine(org.apache.commons.math3.geometry.euclidean.threed.Segment segment)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+      "name": "SubLine",
+      "isArray": false
+    },
+    "name": "getSegments",
+    "returnType": {
+      "qualifiedName": "java.util.List",
+      "name": "List",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getSegments()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+      "name": "SubLine",
+      "isArray": false
+    },
+    "name": "intersection",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+          "name": "SubLine",
+          "isArray": false
+        },
+        "name": "subLine"
+      },
+      {
+        "type": {
+          "qualifiedName": "boolean",
+          "name": "boolean",
+          "isArray": false
+        },
+        "name": "includeEndPoints"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "intersection(org.apache.commons.math3.geometry.euclidean.threed.SubLine subLine,boolean includeEndPoints)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.SubLine",
+      "name": "SubLine",
+      "isArray": false
+    },
+    "name": "buildIntervalSet",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.oned.IntervalsSet",
+      "name": "IntervalsSet",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "start"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "end"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "tolerance"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathIllegalArgumentException",
+          "name": "MathIllegalArgumentException",
+          "isArray": false
+        },
+        "comment": "if the points are equal",
+        "condition": "args[0].equals(args[1])"
+      }
+    ],
+    "signature": "buildIntervalSet(org.apache.commons.math3.geometry.euclidean.threed.Vector3D start,org.apache.commons.math3.geometry.euclidean.threed.Vector3D end,double tolerance)"
+  }
+]

--- a/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.Vector3D_expected.json
+++ b/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.Vector3D_expected.json
@@ -1,0 +1,1292 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "Vector3D",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "x"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "y"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "z"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "Vector3D(double x,double y,double z)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "Vector3D",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double[]",
+          "name": "double[]",
+          "isArray": true,
+          "componentType": {
+            "qualifiedName": "double",
+            "name": "double",
+            "isArray": false
+          }
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.DimensionMismatchException",
+          "name": "DimensionMismatchException",
+          "isArray": false
+        },
+        "comment": "if array does not have 3 elements",
+        "condition": "(args[0].length==3)==false"
+      }
+    ],
+    "signature": "Vector3D(double[] v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "Vector3D",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "alpha"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "delta"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "Vector3D(double alpha,double delta)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "Vector3D",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "Vector3D(double a,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "Vector3D",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u1"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a2"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "Vector3D(double a1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u1,double a2,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "Vector3D",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u1"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a2"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u2"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a3"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u3"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "Vector3D(double a1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u1,double a2,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u2,double a3,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u3)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "Vector3D",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u1"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a2"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u2"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a3"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u3"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a4"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "u4"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "Vector3D(double a1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u1,double a2,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u2,double a3,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u3,double a4,org.apache.commons.math3.geometry.euclidean.threed.Vector3D u4)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getX",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getX()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getY",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getY()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getZ",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getZ()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "toArray",
+    "returnType": {
+      "qualifiedName": "double[]",
+      "name": "double[]",
+      "isArray": true,
+      "componentType": {
+        "qualifiedName": "double",
+        "name": "double",
+        "isArray": false
+      }
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toArray()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getSpace",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.Space",
+      "name": "Space",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getSpace()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getZero",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getZero()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getNorm1",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNorm1()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getNorm",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNorm()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getNormSq",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNormSq()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getNormInf",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getNormInf()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getAlpha",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getAlpha()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "getDelta",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getDelta()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "add",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "add(org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "add",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "factor"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "add(double factor,org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "subtract",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "subtract(org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "subtract",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "factor"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "subtract(double factor,org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "normalize",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the norm is zero",
+        "condition": "target.getNorm()==0"
+      }
+    ],
+    "signature": "normalize()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "orthogonal",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if the norm of the instance is null",
+        "condition": "target.getNorm()==null"
+      }
+    ],
+    "signature": "orthogonal()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "angle",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if either vector has a null norm",
+        "condition": "args[0].getNorm()==null || args[1].getNorm()==null"
+      }
+    ],
+    "signature": "angle(org.apache.commons.math3.geometry.euclidean.threed.Vector3D v1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D v2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "negate",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "negate()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "scalarMultiply",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "a"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "scalarMultiply(double a)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "isNaN",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "isNaN()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "isInfinite",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "isInfinite()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "equals",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "other"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "equals(java.lang.Object other)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "hashCode",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "hashCode()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "dotProduct",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "dotProduct(org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "crossProduct",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "crossProduct(org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distance1",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance1(org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distance",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance(org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distance",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Point",
+          "name": "Point",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance(org.apache.commons.math3.geometry.Point v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distanceInf",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distanceInf(org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distanceSq",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Vector",
+          "name": "Vector",
+          "isArray": false
+        },
+        "name": "v"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distanceSq(org.apache.commons.math3.geometry.Vector v)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "dotProduct",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "dotProduct(org.apache.commons.math3.geometry.euclidean.threed.Vector3D v1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D v2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "crossProduct",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "crossProduct(org.apache.commons.math3.geometry.euclidean.threed.Vector3D v1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D v2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distance1",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance1(org.apache.commons.math3.geometry.euclidean.threed.Vector3D v1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D v2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distance",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance(org.apache.commons.math3.geometry.euclidean.threed.Vector3D v1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D v2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distanceInf",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distanceInf(org.apache.commons.math3.geometry.euclidean.threed.Vector3D v1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D v2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "distanceSq",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "v2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distanceSq(org.apache.commons.math3.geometry.euclidean.threed.Vector3D v1,org.apache.commons.math3.geometry.euclidean.threed.Vector3D v2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "toString",
+    "returnType": {
+      "qualifiedName": "java.lang.String",
+      "name": "String",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toString()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "name": "toString",
+    "returnType": {
+      "qualifiedName": "java.lang.String",
+      "name": "String",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.text.NumberFormat",
+          "name": "NumberFormat",
+          "isArray": false
+        },
+        "name": "format"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "toString(java.text.NumberFormat format)"
+  }
+]

--- a/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.geometry.spherical.twod.S2Point_expected.json
+++ b/src/test/resources/expected-output/CommonsMath-3.6.1/org.apache.commons.math3.geometry.spherical.twod.S2Point_expected.json
@@ -1,0 +1,358 @@
+[
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "S2Point",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "theta"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "phi"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.OutOfRangeException",
+          "name": "OutOfRangeException",
+          "isArray": false
+        },
+        "comment": "if \\( \\varphi \\) is not in the [\\( 0; \\pi \\)] range",
+        "condition": ""
+      }
+    ],
+    "signature": "S2Point(double theta,double phi)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "S2Point",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "vector"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.MathArithmeticException",
+          "name": "MathArithmeticException",
+          "isArray": false
+        },
+        "comment": "if vector norm is zero",
+        "condition": "args[0].getNorm()==0"
+      }
+    ],
+    "signature": "S2Point(org.apache.commons.math3.geometry.euclidean.threed.Vector3D vector)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "S2Point",
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "theta"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "phi"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+          "name": "Vector3D",
+          "isArray": false
+        },
+        "name": "vector"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "S2Point(double theta,double phi,org.apache.commons.math3.geometry.euclidean.threed.Vector3D vector)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "vector",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "theta"
+      },
+      {
+        "type": {
+          "qualifiedName": "double",
+          "name": "double",
+          "isArray": false
+        },
+        "name": "phi"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "org.apache.commons.math3.exception.OutOfRangeException",
+          "name": "OutOfRangeException",
+          "isArray": false
+        },
+        "comment": "if \\( \\varphi \\) is not in the [\\( 0; \\pi \\)] range",
+        "condition": ""
+      }
+    ],
+    "signature": "vector(double theta,double phi)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "getTheta",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getTheta()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "getPhi",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getPhi()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "getVector",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.euclidean.threed.Vector3D",
+      "name": "Vector3D",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getVector()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "getSpace",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.Space",
+      "name": "Space",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "getSpace()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "isNaN",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "isNaN()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "negate",
+    "returnType": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "negate()"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "distance",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.Point",
+          "name": "Point",
+          "isArray": false
+        },
+        "name": "point"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance(org.apache.commons.math3.geometry.Point point)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "distance",
+    "returnType": {
+      "qualifiedName": "double",
+      "name": "double",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+          "name": "S2Point",
+          "isArray": false
+        },
+        "name": "p1"
+      },
+      {
+        "type": {
+          "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+          "name": "S2Point",
+          "isArray": false
+        },
+        "name": "p2"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "distance(org.apache.commons.math3.geometry.spherical.twod.S2Point p1,org.apache.commons.math3.geometry.spherical.twod.S2Point p2)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "equals",
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "other"
+      }
+    ],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "equals(java.lang.Object other)"
+  },
+  {
+    "containingClass": {
+      "qualifiedName": "org.apache.commons.math3.geometry.spherical.twod.S2Point",
+      "name": "S2Point",
+      "isArray": false
+    },
+    "name": "hashCode",
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "isVarArgs": false,
+    "throwsTags": [],
+    "signature": "hashCode()"
+  }
+]


### PR DESCRIPTION
## Added classes to the PrecisionRecall test of CommonsMath3
- Line
- SubLine
- BigFraction
- Fraction (This .json read fails. Log at the end)
- Vector3D
- S2Point

## Added direct translations for:
- "smaller than", "smaller than or equal to"
- "strictly positive", "strictly negative"

Checked in my class: 
```
[main] TRACE org.toradocu.translator.ConditionTranslator - Identifying propositions from: "if myvar is strictly positive" in Test1(java.lang.Integer myvar,java.lang.Integer myvares)
done [1.5 sec].
[main] TRACE org.toradocu.translator.ConditionTranslator - Translated proposition (myvar, is positive) as: args[0]>0
[main] TRACE org.toradocu.translator.ConditionTranslator - Identifying propositions from: "if myvar is strictly negative" in Test2(java.lang.Integer myvar,java.lang.Integer myvares)
[main] TRACE org.toradocu.translator.ConditionTranslator - Translated proposition (myvar, is negative) as: args[0]<0
[main] TRACE org.toradocu.translator.ConditionTranslator - Identifying propositions from: "if myvar is smaller than 3" in Test3(java.lang.Integer myvar,java.lang.Integer myvares)
[main] TRACE org.toradocu.translator.ConditionTranslator - Translated proposition (myvar, is < 3) as: args[0]<3
[main] TRACE org.toradocu.translator.ConditionTranslator - Identifying propositions from: "if myvar is smaller than or equal to 3" in Test4(java.lang.Integer myvar,java.lang.Integer myvares)
[main] TRACE org.toradocu.translator.ConditionTranslator - Translated proposition (myvar, is <= 3) as: args[0]<=3
/home/sergio/Toradocu/Test.json:40: "comment": "if myvar is strictly positive",
/home/sergio/Toradocu/Test.json:41: "condition": "args[0]>0"

/home/sergio/Toradocu/Test.json:84: "comment": "if myvar is strictly negative",
/home/sergio/Toradocu/Test.json:85: "condition": "args[0]<0"

/home/sergio/Toradocu/Test.json:128: "comment": "if myvar is smaller than 3",
/home/sergio/Toradocu/Test.json:129: "condition": "args[0]<3"

/home/sergio/Toradocu/Test.json:172: "comment": "if myvar is smaller than or equal to 3",
/home/sergio/Toradocu/Test.json:173: "condition": "args[0]<=3"

[main] INFO org.toradocu.generator.OracleGenerator - Oracle generator disabled: skipped aspect generation.
```

Log of Fraction in JUnit test:
```
fractionTest(org.toradocu.PrecisionRecallCommonsMath3)
com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 2 column 4 path $
	at com.google.gson.Gson.fromJson(Gson.java:899)
	at com.google.gson.Gson.fromJson(Gson.java:852)
	at org.toradocu.testlib.PrecisionRecallTest.compare(PrecisionRecallTest.java:91)
	at org.toradocu.testlib.PrecisionRecallTest.computePrecisionAndRecall(PrecisionRecallTest.java:64)
	at org.toradocu.testlib.AbstractPrecisionRecallTestSuite.computePrecisionAndRecall(AbstractPrecisionRecallTestSuite.java:93)
	at org.toradocu.testlib.AbstractPrecisionRecallTestSuite.test(AbstractPrecisionRecallTestSuite.java:108)
	at org.toradocu.PrecisionRecallCommonsMath3.fractionTest(PrecisionRecallCommonsMath3.java:85)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:678)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)
Caused by: java.lang.IllegalStateException: Expected BEGIN_ARRAY but was BEGIN_OBJECT at line 2 column 4 path $
	at com.google.gson.stream.JsonReader.beginArray(JsonReader.java:350)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:80)
	at com.google.gson.internal.bind.CollectionTypeAdapterFactory$Adapter.read(CollectionTypeAdapterFactory.java:61)
	at com.google.gson.Gson.fromJson(Gson.java:887)
	... 31 more 
```

