### PR TITLE
Add subjects to precision/recall suite. Improve translation of predicates containing numbers

### DIFF
--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -70,7 +70,9 @@ public class ConditionTranslator {
     // Replace written out inequalities with symbols.
     text =
         text.replace("greater than or equal to", ">=")
+            .replace("≥", ">=")
             .replace("less than or equal to", "<=")
+            .replace("≤", "<=")
             .replace("greater than", ">")
             .replace("smaller than or equal to", "<=")
             .replace("smaller than", "<")
@@ -147,7 +149,8 @@ public class ConditionTranslator {
     return placeholderText;
   }
 
-  private static final String INEQUALITY_NUMBER_REGEX = " *(([<>=]=?)|(!=)) ?-?[0-9]+";
+  private static final String INEQUALITY_NUMBER_REGEX =
+      " *((([<>=]=?)|(!=)) ?)-?([0-9]+|zero|one|two|three|four|five|six|seven|eight|nine)";
   private static final String PLACEHOLDER_PREFIX = " INEQUALITY_";
   private static final String INEQ_INSOF = " *[an]* (instance of)"; // e.g "an instance of"
   private static final String INEQ_INSOFPROCESSED =

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -266,7 +266,7 @@ class Matcher {
     String verbs = "(is|are|be|is equal to|are equal to|equals to) ?";
 
     String predicates =
-        "(true|false|null|this|zero|positive|strictly positive|negative|strictly negative)";
+        "(true|false|null|this|zero|positive|strictly positive|negative|strictly negative|nonnegative|nonpositive)";
 
     java.util.regex.Matcher isPattern =
         Pattern.compile(verbs + "(==|=)? ?" + predicates).matcher(predicate);
@@ -275,7 +275,10 @@ class Matcher {
         Pattern.compile(verbs + "(!=)? ?" + predicates).matcher(predicate);
 
     java.util.regex.Matcher inequality =
-        Pattern.compile(verbs + "(<=|>=|<|>|!=|==|=)? ?(-?[0-9]+)").matcher(predicate);
+        Pattern.compile(
+                verbs
+                    + "(<=|>=|<|>|!=|==|=)? ?(-?([0-9]+|zero|one|two|three|four|five|six|seven|eight|nine))")
+            .matcher(predicate);
 
     java.util.regex.Matcher instanceOf = Pattern.compile("(instanceof) (.*)").matcher(predicate);
 
@@ -303,6 +306,12 @@ class Matcher {
         case "strictly negative":
           predicateTranslation = "<0";
           break;
+        case "nonnegative":
+          predicateTranslation = ">=0";
+          break;
+        case "nonpositive":
+          predicateTranslation = "<=0";
+          break;
         default:
           predicateTranslation = null;
       }
@@ -319,11 +328,17 @@ class Matcher {
           break;
         case "positive":
         case "strictly positive":
-          predicateTranslation = "<0";
+          predicateTranslation = ">0";
           break;
         case "negative":
         case "strictly negative":
           predicateTranslation = "<0";
+          break;
+        case "nonnegative":
+          predicateTranslation = ">=0";
+          break;
+        case "nonpositive":
+          predicateTranslation = "<=0";
           break;
         default:
           predicateTranslation = null;
@@ -333,7 +348,11 @@ class Matcher {
       String numberString = inequality.group(inequality.groupCount());
       // Get the symbol from the regular expression.
       String relation = inequality.group(2);
-      int number = Integer.parseInt(numberString);
+      String numberWord = isNumberWord(numberString);
+      int number =
+          (!numberWord.equals(""))
+              ? number = Integer.parseInt(numberWord)
+              : Integer.parseInt(numberString);
       // relation is null in predicates without inequalities. For example "is 0".
       if (relation == null || relation.equals("=")) {
         predicateTranslation = "==" + number;
@@ -348,5 +367,32 @@ class Matcher {
       predicateTranslation = null;
     }
     return predicateTranslation;
+  }
+
+  private static String isNumberWord(String numberString) {
+    switch (numberString) {
+      case "zero":
+        return "0";
+      case "one":
+        return "1";
+      case "two":
+        return "2";
+      case "three":
+        return "3";
+      case "four":
+        return "4";
+      case "five":
+        return "5";
+      case "six":
+        return "6";
+      case "seven":
+        return "7";
+      case "eight":
+        return "8";
+      case "nine":
+        return "9";
+    }
+
+    return "";
   }
 }

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -348,7 +348,7 @@ class Matcher {
       String numberString = inequality.group(inequality.groupCount());
       // Get the symbol from the regular expression.
       String relation = inequality.group(2);
-      String numberWord = isNumberWord(numberString);
+      String numberWord = numberWordToDigit(numberString);
       int number =
           (!numberWord.equals(""))
               ? number = Integer.parseInt(numberWord)
@@ -369,7 +369,7 @@ class Matcher {
     return predicateTranslation;
   }
 
-  private static String isNumberWord(String numberString) {
+  private static String numberWordToDigit(String numberString) {
     switch (numberString) {
       case "zero":
         return "0";

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsCollections4.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsCollections4.java
@@ -63,7 +63,7 @@ public class PrecisionRecallCommonsCollections4 extends AbstractPrecisionRecallT
 
   @Test
   public void testLRUMap() throws Exception {
-    test("org.apache.commons.collections4.map.LRUMap", 0.824, 0.482, 1, 0.857, 1, 0.333);
+    test("org.apache.commons.collections4.map.LRUMap", 0.857, 0.621, 1, 0.857, 1, 0.333);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -42,7 +42,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testPrimes() throws Exception {
-    test("org.apache.commons.math3.primes.Primes", 1, 1, 0, 0, 1, 1);
+    test("org.apache.commons.math3.primes.Primes", 1, 1, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallGuava19.java
+++ b/src/test/java/org/toradocu/PrecisionRecallGuava19.java
@@ -20,7 +20,7 @@ public class PrecisionRecallGuava19 extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testCharMatcher() throws Exception {
-    test("com.google.common.base.CharMatcher", 0, 0, 1, 0, 1, 1);
+    test("com.google.common.base.CharMatcher", 0, 0, 0, 0, 1, 1);
   }
 
   @Test
@@ -45,7 +45,7 @@ public class PrecisionRecallGuava19 extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testIterators() throws Exception {
-    test("com.google.common.collect.Iterators", 1, 0.6, 1, 1, 1, 1);
+    test("com.google.common.collect.Iterators", 1, 1, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallJGraphT.java
+++ b/src/test/java/org/toradocu/PrecisionRecallJGraphT.java
@@ -58,4 +58,9 @@ public class PrecisionRecallJGraphT extends AbstractPrecisionRecallTestSuite {
   public void testDirectedAcyclicGraph() throws Exception {
     test("org.jgrapht.experimental.dag.DirectedAcyclicGraph", 1, 0.428, 1, 1, 1, 0);
   }
+
+  @Test
+  public void testPatonCycleBase() throws Exception {
+    test("org.jgrapht.alg.cycle.PatonCycleBase", 1, 1, 1, 1, 1, 1);
+  }
 }

--- a/src/test/java/org/toradocu/PrecisionRecallPlumeLib.java
+++ b/src/test/java/org/toradocu/PrecisionRecallPlumeLib.java
@@ -30,6 +30,16 @@ public class PrecisionRecallPlumeLib extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testWeakIdentityHashMap() throws Exception {
-    test("plume.WeakIdentityHashMap", 0.75, 0.75, 1, 1, 1, 1);
+    test("plume.WeakIdentityHashMap", 1, 1, 1, 1, 1, 1);
+  }
+
+  @Test
+  public void testTimeLimitProcess() throws Exception {
+    test("plume.TimeLimitProcess", 1, 1, 1, 0, 1, 0);
+  }
+
+  @Test
+  public void testWeakHasherMap() throws Exception {
+    test("plume.WeakHasherMap", 1, 1, 1, 1, 1, 1);
   }
 }

--- a/src/test/resources/goal-output/commons-collections4-4.1/org.apache.commons.collections4.map.LRUMap_goal.json
+++ b/src/test/resources/goal-output/commons-collections4-4.1/org.apache.commons.collections4.map.LRUMap_goal.json
@@ -278,7 +278,7 @@
       },
       {
         "comment": "if the load factor is less than zero",
-        "condition": "args[1]<1",
+        "condition": "args[1]<0",
         "exception": {
           "isArray": false,
           "name": "IllegalArgumentException",
@@ -488,7 +488,7 @@
       },
       {
         "comment": "if the load factor is less than zero",
-        "condition": "args[1]<1",
+        "condition": "args[1]<0",
         "exception": {
           "isArray": false,
           "name": "IllegalArgumentException",

--- a/src/test/resources/goal-output/commons-collections4-4.1/org.apache.commons.collections4.map.LRUMap_goal.json
+++ b/src/test/resources/goal-output/commons-collections4-4.1/org.apache.commons.collections4.map.LRUMap_goal.json
@@ -278,7 +278,7 @@
       },
       {
         "comment": "if the load factor is less than zero",
-        "condition": "args[0]<1",
+        "condition": "args[1]<1",
         "exception": {
           "isArray": false,
           "name": "IllegalArgumentException",
@@ -488,7 +488,7 @@
       },
       {
         "comment": "if the load factor is less than zero",
-        "condition": "args[0]<1",
+        "condition": "args[1]<1",
         "exception": {
           "isArray": false,
           "name": "IllegalArgumentException",

--- a/src/test/resources/goal-output/guava-19.0/com.google.common.collect.Iterators_goal.json
+++ b/src/test/resources/goal-output/guava-19.0/com.google.common.collect.Iterators_goal.json
@@ -1048,7 +1048,7 @@
           "size"
         ],
         "comment": "if size is nonpositive",
-        "condition": "args[1]<0",
+        "condition": "args[1]<=0",
         "exception": {
           "isArray": false,
           "name": "IllegalArgumentException",
@@ -1130,7 +1130,7 @@
           "size"
         ],
         "comment": "if size is nonpositive",
-        "condition": "args[1]<0",
+        "condition": "args[1]<=0",
         "exception": {
           "isArray": false,
           "name": "IllegalArgumentException",

--- a/src/test/resources/goal-output/jgrapht-core-0.9.2/org.jgrapht.alg.cycle.PatonCycleBase_goal.json
+++ b/src/test/resources/goal-output/jgrapht-core-0.9.2/org.jgrapht.alg.cycle.PatonCycleBase_goal.json
@@ -164,7 +164,7 @@
     "returnTag": {
       "comment": "A list of cycles constituting a cycle base for the graph. Possibly empty but never null.",
       "kind": "RETURN",
-      "condition": ""
+      "condition": "true ? result != null"
     },
     "throwsTags": [
       {

--- a/src/test/resources/goal-output/jgrapht-core-0.9.2/org.jgrapht.alg.cycle.PatonCycleBase_goal.json
+++ b/src/test/resources/goal-output/jgrapht-core-0.9.2/org.jgrapht.alg.cycle.PatonCycleBase_goal.json
@@ -1,0 +1,183 @@
+[
+  {
+    "signature": "PatonCycleBase()",
+    "name": "PatonCycleBase",
+    "containingClass": {
+      "qualifiedName": "org.jgrapht.alg.cycle.PatonCycleBase",
+      "name": "PatonCycleBase",
+      "isArray": false
+    },
+    "targetClass": "org.jgrapht.alg.cycle.PatonCycleBase",
+    "isVarArgs": false,
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "PatonCycleBase(org.jgrapht.UndirectedGraph graph)",
+    "name": "PatonCycleBase",
+    "containingClass": {
+      "qualifiedName": "org.jgrapht.alg.cycle.PatonCycleBase",
+      "name": "PatonCycleBase",
+      "isArray": false
+    },
+    "targetClass": "org.jgrapht.alg.cycle.PatonCycleBase",
+    "isVarArgs": false,
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.jgrapht.UndirectedGraph",
+          "name": "UndirectedGraph",
+          "isArray": false
+        },
+        "name": "graph"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "org.jgrapht.UndirectedGraph",
+            "name": "UndirectedGraph",
+            "isArray": false
+          },
+          "name": "graph"
+        },
+        "comment": "- the DirectedGraph in which to find cycles.",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "codeTags": [
+          "null"
+        ],
+        "comment": "if the graph argument is null.",
+        "kind": "THROWS",
+        "condition": "args[0]==null"
+      }
+    ]
+  },
+  {
+    "signature": "getGraph()",
+    "name": "getGraph",
+    "containingClass": {
+      "qualifiedName": "org.jgrapht.alg.cycle.PatonCycleBase",
+      "name": "PatonCycleBase",
+      "isArray": false
+    },
+    "targetClass": "org.jgrapht.alg.cycle.PatonCycleBase",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "org.jgrapht.UndirectedGraph",
+      "name": "UndirectedGraph",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "The graph.",
+      "kind": "RETURN",
+      "condition": "true ? result==target.graph"
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "setGraph(org.jgrapht.UndirectedGraph graph)",
+    "name": "setGraph",
+    "containingClass": {
+      "qualifiedName": "org.jgrapht.alg.cycle.PatonCycleBase",
+      "name": "PatonCycleBase",
+      "isArray": false
+    },
+    "targetClass": "org.jgrapht.alg.cycle.PatonCycleBase",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "org.jgrapht.UndirectedGraph",
+          "name": "UndirectedGraph",
+          "isArray": false
+        },
+        "name": "graph"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "org.jgrapht.UndirectedGraph",
+            "name": "UndirectedGraph",
+            "isArray": false
+          },
+          "name": "graph"
+        },
+        "comment": "the graph.",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "codeTags": [
+          "null"
+        ],
+        "comment": "if the argument is null.",
+        "kind": "THROWS",
+        "condition": "args[0]==null"
+      }
+    ]
+  },
+  {
+    "signature": "findCycleBase()",
+    "name": "findCycleBase",
+    "containingClass": {
+      "qualifiedName": "org.jgrapht.alg.cycle.PatonCycleBase",
+      "name": "PatonCycleBase",
+      "isArray": false
+    },
+    "targetClass": "org.jgrapht.alg.cycle.PatonCycleBase",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.util.List",
+      "name": "List",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "A list of cycles constituting a cycle base for the graph. Possibly empty but never null.",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "codeTags": [],
+        "comment": "if the current graph is null.",
+        "kind": "THROWS",
+        "condition": "target.getGraph()==null"
+      }
+    ]
+  }
+]

--- a/src/test/resources/goal-output/plume-lib-1.1.0/plume.TimeLimitProcess_goal.json
+++ b/src/test/resources/goal-output/plume-lib-1.1.0/plume.TimeLimitProcess_goal.json
@@ -1,0 +1,452 @@
+[
+  {
+    "signature": "TimeLimitProcess(java.lang.Process p,long timeLimit)",
+    "name": "TimeLimitProcess",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Process",
+          "name": "Process",
+          "isArray": false
+        },
+        "name": "p"
+      },
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "timeLimit"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "java.lang.Process",
+            "name": "Process",
+            "isArray": false
+          },
+          "name": "p"
+        },
+        "comment": "non-null Process to limit the execution of",
+        "kind": "PARAM",
+        "condition": "args[0]!=null"
+      },
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "long",
+            "name": "long",
+            "isArray": false
+          },
+          "name": "timeLimit"
+        },
+        "comment": "in milliseconds",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": []
+  },
+  {
+    "signature": "TimeLimitProcess(java.lang.Process p,long timeLimit,boolean cacheStdout)",
+    "name": "TimeLimitProcess",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Process",
+          "name": "Process",
+          "isArray": false
+        },
+        "name": "p"
+      },
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "timeLimit"
+      },
+      {
+        "type": {
+          "qualifiedName": "boolean",
+          "name": "boolean",
+          "isArray": false
+        },
+        "name": "cacheStdout"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "java.lang.Process",
+            "name": "Process",
+            "isArray": false
+          },
+          "name": "p"
+        },
+        "comment": "non-null Process to limit the execution of",
+        "kind": "PARAM",
+        "condition": "args[0]!=null"
+      },
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "long",
+            "name": "long",
+            "isArray": false
+          },
+          "name": "timeLimit"
+        },
+        "comment": "in milliseconds",
+        "kind": "PARAM",
+        "condition": ""
+      },
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "boolean",
+            "name": "boolean",
+            "isArray": false
+          },
+          "name": "cacheStdout"
+        },
+        "comment": "If true, causes the TimeLimitProcess to consume the standard output of the underlying process, and to cache it. After the process terminates (on its own or by being timed out), the output is available via the cached_stdout method. This is necessary because when a Java process is terminated, its standard output is no longer available.",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": []
+  },
+  {
+    "signature": "timed_out()",
+    "name": "timed_out",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "true iff the process has timed out",
+      "kind": "RETURN",
+      "condition": "true ? target.timed_out"
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "timeout_msecs()",
+    "name": "timeout_msecs",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "long",
+      "name": "long",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "the timeout time in msecs",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "destroy()",
+    "name": "destroy",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "exitValue()",
+    "name": "exitValue",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "the exit value for the subprocess",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "getErrorStream()",
+    "name": "getErrorStream",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.io.InputStream",
+      "name": "InputStream",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "the error stream",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "getInputStream()",
+    "name": "getInputStream",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.io.InputStream",
+      "name": "InputStream",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "the input stream",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "stringToInputStream(java.lang.String text)",
+    "name": "stringToInputStream",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.io.InputStream",
+      "name": "InputStream",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.String",
+          "name": "String",
+          "isArray": false
+        },
+        "name": "text"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "getOutputStream()",
+    "name": "getOutputStream",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.io.OutputStream",
+      "name": "OutputStream",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "the output stream",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "waitFor()",
+    "name": "waitFor",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "the exit value of the subprocess",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "finished()",
+    "name": "finished",
+    "containingClass": {
+      "qualifiedName": "plume.TimeLimitProcess",
+      "name": "TimeLimitProcess",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "returnTag": {
+      "comment": "true if the process if finished, false otherwise",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "waitFor(long arg0,java.util.concurrent.TimeUnit arg1)",
+    "name": "waitFor",
+    "containingClass": {
+      "qualifiedName": "java.lang.Process",
+      "name": "Process",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "long",
+          "name": "long",
+          "isArray": false
+        },
+        "name": "arg0"
+      },
+      {
+        "type": {
+          "qualifiedName": "java.util.concurrent.TimeUnit",
+          "name": "TimeUnit",
+          "isArray": false
+        },
+        "name": "arg1"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "destroyForcibly()",
+    "name": "destroyForcibly",
+    "containingClass": {
+      "qualifiedName": "java.lang.Process",
+      "name": "Process",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.lang.Process",
+      "name": "Process",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "isAlive()",
+    "name": "isAlive",
+    "containingClass": {
+      "qualifiedName": "java.lang.Process",
+      "name": "Process",
+      "isArray": false
+    },
+    "targetClass": "plume.TimeLimitProcess",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  }
+]

--- a/src/test/resources/goal-output/plume-lib-1.1.0/plume.WeakHasherMap_goal.json
+++ b/src/test/resources/goal-output/plume-lib-1.1.0/plume.WeakHasherMap_goal.json
@@ -1,0 +1,809 @@
+[
+  {
+    "signature": "WeakHasherMap(int initialCapacity,float loadFactor)",
+    "name": "WeakHasherMap",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "initialCapacity"
+      },
+      {
+        "type": {
+          "qualifiedName": "float",
+          "name": "float",
+          "isArray": false
+        },
+        "name": "loadFactor"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "int",
+            "name": "int",
+            "isArray": false
+          },
+          "name": "initialCapacity"
+        },
+        "comment": "the initial capacity of the WeakHashMap",
+        "kind": "PARAM",
+        "condition": ""
+      },
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "float",
+            "name": "float",
+            "isArray": false
+          },
+          "name": "loadFactor"
+        },
+        "comment": "the load factor of the WeakHashMap",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "codeTags": [],
+        "comment": "If the initial capacity is less than zero, or if the load factor is nonpositive",
+        "kind": "THROWS",
+        "condition": "args[0]<0 || args[1]<=0"
+      }
+    ]
+  },
+  {
+    "signature": "WeakHasherMap(int initialCapacity)",
+    "name": "WeakHasherMap",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "int",
+          "name": "int",
+          "isArray": false
+        },
+        "name": "initialCapacity"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "int",
+            "name": "int",
+            "isArray": false
+          },
+          "name": "initialCapacity"
+        },
+        "comment": "the initial capacity of the WeakHashMap",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": [
+      {
+        "exception": {
+          "qualifiedName": "java.lang.IllegalArgumentException",
+          "name": "IllegalArgumentException",
+          "isArray": false
+        },
+        "codeTags": [],
+        "comment": "If the initial capacity is less than zero",
+        "kind": "THROWS",
+        "condition": "args[0]<0"
+      }
+    ]
+  },
+  {
+    "signature": "WeakHasherMap()",
+    "name": "WeakHasherMap",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "WeakHasherMap(plume.Hasher h)",
+    "name": "WeakHasherMap",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "plume.Hasher",
+          "name": "Hasher",
+          "isArray": false
+        },
+        "name": "h"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "plume.Hasher",
+            "name": "Hasher",
+            "isArray": false
+          },
+          "name": "h"
+        },
+        "comment": "the Hasher to use when hashing values for this map",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": []
+  },
+  {
+    "signature": "keyEquals(java.lang.Object k1,java.lang.Object k2)",
+    "name": "keyEquals",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "k1"
+      },
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "k2"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "keyHashCode(java.lang.Object k1)",
+    "name": "keyHashCode",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "k1"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "WeakKeyCreate(java.lang.Object k)",
+    "name": "WeakKeyCreate",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "plume.WeakHasherMap.WeakKey",
+      "name": "WeakKey",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "k"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "WeakKeyCreate(java.lang.Object k,java.lang.ref.ReferenceQueue q)",
+    "name": "WeakKeyCreate",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "plume.WeakHasherMap.WeakKey",
+      "name": "WeakKey",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "k"
+      },
+      {
+        "type": {
+          "qualifiedName": "java.lang.ref.ReferenceQueue",
+          "name": "ReferenceQueue",
+          "isArray": false
+        },
+        "name": "q"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "processQueue()",
+    "name": "processQueue",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "size()",
+    "name": "size",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "isEmpty()",
+    "name": "isEmpty",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "containsKey(java.lang.Object key)",
+    "name": "containsKey",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "key"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "java.lang.Object",
+            "name": "Object",
+            "isArray": false
+          },
+          "name": "key"
+        },
+        "comment": "the key whose presence in this map is to be tested",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": []
+  },
+  {
+    "signature": "get(java.lang.Object key)",
+    "name": "get",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "V",
+      "name": "V",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "key"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "java.lang.Object",
+            "name": "Object",
+            "isArray": false
+          },
+          "name": "key"
+        },
+        "comment": "the key whose associated value, if any, is to be returned",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "throwsTags": []
+  },
+  {
+    "signature": "put(java.lang.Object key,java.lang.Object value)",
+    "name": "put",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "V",
+      "name": "V",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "key"
+      },
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "value"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "java.lang.Object",
+            "name": "Object",
+            "isArray": false
+          },
+          "name": "key"
+        },
+        "comment": "the key that is to be mapped to the given value",
+        "kind": "PARAM",
+        "condition": ""
+      },
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "java.lang.Object",
+            "name": "Object",
+            "isArray": false
+          },
+          "name": "value"
+        },
+        "comment": "the value to which the given key is to be mapped",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "returnTag": {
+      "comment": "the previous value to which this key was mapped, or null if if there was no mapping for the key",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "remove(java.lang.Object key)",
+    "name": "remove",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "V",
+      "name": "V",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "key"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "java.lang.Object",
+            "name": "Object",
+            "isArray": false
+          },
+          "name": "key"
+        },
+        "comment": "the key whose mapping is to be removed",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "returnTag": {
+      "comment": "the value to which this key was mapped, or null if there was no mapping for the key",
+      "kind": "RETURN",
+      "condition": ""
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "clear()",
+    "name": "clear",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "entrySet()",
+    "name": "entrySet",
+    "containingClass": {
+      "qualifiedName": "plume.WeakHasherMap",
+      "name": "WeakHasherMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.util.Set",
+      "name": "Set",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "containsValue(java.lang.Object arg0)",
+    "name": "containsValue",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "arg0"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "putAll(java.util.Map arg0)",
+    "name": "putAll",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "void",
+      "name": "void",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.util.Map",
+          "name": "Map",
+          "isArray": false
+        },
+        "name": "arg0"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "keySet()",
+    "name": "keySet",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.util.Set",
+      "name": "Set",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "values()",
+    "name": "values",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.util.Collection",
+      "name": "Collection",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "equals(java.lang.Object arg0)",
+    "name": "equals",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "arg0"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "hashCode()",
+    "name": "hashCode",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "int",
+      "name": "int",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "toString()",
+    "name": "toString",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.lang.String",
+      "name": "String",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "clone()",
+    "name": "clone",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "java.lang.Object",
+      "name": "Object",
+      "isArray": false
+    },
+    "parameters": [],
+    "paramTags": [],
+    "throwsTags": []
+  },
+  {
+    "signature": "eq(java.lang.Object arg0,java.lang.Object arg1)",
+    "name": "eq",
+    "containingClass": {
+      "qualifiedName": "java.util.AbstractMap",
+      "name": "AbstractMap",
+      "isArray": false
+    },
+    "targetClass": "plume.WeakHasherMap",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "arg0"
+      },
+      {
+        "type": {
+          "qualifiedName": "java.lang.Object",
+          "name": "Object",
+          "isArray": false
+        },
+        "name": "arg1"
+      }
+    ],
+    "paramTags": [],
+    "throwsTags": []
+  }
+]


### PR DESCRIPTION
Add the last subject from JGraphT and 2 from PlumeLib.
Add support for predicates:  "is nonpositive", "is nonnegative", "is ≤" and "is  ≥".
Add support for numbers expressed as words, from "zero" to "nine".
Fixes of tests and some goal files for: PlumeLib; CommonsCollections4; CommonsMath3; Guava.