### PR TITLE
Improve extraction of the subject

### DIFF
--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -41,10 +42,12 @@ class Matcher {
 
     // Clean the subject string by removing words and characters not related to its identity so that
     // they do not influence string matching.
-    if (subject.startsWith("either ")) {
-      subject = subject.replaceFirst("either ", "");
-    } else if (subject.startsWith("both ")) {
-      subject = subject.replaceFirst("both ", "");
+    List<String> wordsToRemove = Arrays.asList("either", "both", "any");
+    for (String word : wordsToRemove) {
+      String wordToReplace = word + " ";
+      if (subject.startsWith(wordToReplace)) {
+        subject = subject.replaceFirst(wordToReplace, "");
+      }
     }
     subject = subject.trim();
 

--- a/src/main/java/org/toradocu/translator/ParameterCodeElement.java
+++ b/src/main/java/org/toradocu/translator/ParameterCodeElement.java
@@ -31,9 +31,11 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
     addIdentifier(name);
     addIdentifier(parameter.getType().getSimpleName() + " " + name);
     addIdentifier(name + " " + parameter.getType().getSimpleName());
-    // Add name identifier splitting camel case name into different words.
+    // Add name identifier splitting camel case name into different words. We consider as
+    // identifier the single words, and a string composed by the words separated by whitespace.
     StringJoiner joiner = new StringJoiner(" ");
     for (String word : name.split("(?<!(^|[A-Z]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])")) {
+      addIdentifier(word);
       joiner.add(word);
     }
     addIdentifier(joiner.toString().toLowerCase());

--- a/src/main/java/org/toradocu/translator/SentenceParser.java
+++ b/src/main/java/org/toradocu/translator/SentenceParser.java
@@ -343,8 +343,6 @@ public class SentenceParser {
    *     articles)
    */
   private Subject getSubject(IndexedWord subjectWord) {
-    final List<String> ARTICLES = Collections.unmodifiableList(Arrays.asList("a", "an", "the"));
-
     // Collect the words composing the container. For example, in the comment "any value in the
     // array is null", the subject is "any value", while the container is "array". At the moment
     // we collect only one word as container. Extend the code to support containers composed of
@@ -408,6 +406,14 @@ public class SentenceParser {
     return foundRelations;
   }
 
+  /**
+   * Collects all the words composing a subject in a proposition, given the node that is marked as
+   * subject by the Stanford parser. Subject words appear in the returned list in the order they
+   * appear in the input sentence.
+   *
+   * @param subject the subject node
+   * @return a list of words representing the subject of a proposition
+   */
   private List<IndexedWord> extractSubjectWords(IndexedWord subject) {
     List<IndexedWord> subjectWords = new ArrayList<>();
     Queue<IndexedWord> nodeQueue = new LinkedList<>();
@@ -425,6 +431,15 @@ public class SentenceParser {
     return subjectWords;
   }
 
+  /**
+   * Returns the list of children of {@code node} in the semantic graph produce by the Stanford
+   * parser. The list of children only contains nodes that are connected with {@code node} with the
+   * grammatical relations listed in {@code relationIdentifiers}. Also, nodes containing a stopword
+   * (e.g., "a", "an", "the") are ignored.
+   *
+   * @param node a node in the semantic graph
+   * @return the filtered list of children
+   */
   private List<IndexedWord> getChildren(IndexedWord node) {
     List<String> relationIdentifiers =
         Arrays.asList("compound", "advmod", "amod", "det", "nmod:poss", "nmod:of");

--- a/src/main/java/org/toradocu/translator/SentenceParser.java
+++ b/src/main/java/org/toradocu/translator/SentenceParser.java
@@ -7,11 +7,14 @@ import edu.stanford.nlp.trees.GrammaticalRelation;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
+import java.util.Queue;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +90,7 @@ public class SentenceParser {
       List<IndexedWord> subjectWords = subject.getSubjectWords();
       // Create a Proposition from the subject and predicate words.
       String predicateWordsAsString =
-          predicateWords.stream().map(w -> w.word()).collect(Collectors.joining(" "));
+          predicateWords.stream().map(IndexedWord::word).collect(Collectors.joining(" "));
       Proposition proposition = new Proposition(subject, predicateWordsAsString, negative);
 
       // Add the Proposition and associated words to the propositionMap.
@@ -342,17 +345,6 @@ public class SentenceParser {
   private Subject getSubject(IndexedWord subjectWord) {
     final List<String> ARTICLES = Collections.unmodifiableList(Arrays.asList("a", "an", "the"));
 
-    // Collect the words composing the subject in comments.
-    List<IndexedWord> subjectWords =
-        getRelationsFromGraph("compound", "det", "advmod", "amod", "nmod:poss")
-            .stream()
-            .filter(e -> e.getGovernor().equals(subjectWord))
-            .filter(e -> !ARTICLES.contains(e.getDependent().word()))
-            .map(e -> e.getDependent())
-            .sorted((w1, w2) -> Integer.compare(w1.index(), w2.index()))
-            .collect(Collectors.toList());
-    subjectWords.add(subjectWord); // TODO: Why we assume that the subject is the last word?
-
     // Collect the words composing the container. For example, in the comment "any value in the
     // array is null", the subject is "any value", while the container is "array". At the moment
     // we collect only one word as container. Extend the code to support containers composed of
@@ -363,14 +355,14 @@ public class SentenceParser {
         getRelationsFromGraph("nmod:in")
             .stream()
             .filter(e -> e.getGovernor().equals(subjectWord))
-            .map(e -> e.getDependent())
+            .map(SemanticGraphEdge::getDependent)
             .findFirst()
             .orElse(null);
     if (container != null) {
       containerWords.add(container);
     }
 
-    return new Subject(subjectWords, containerWords);
+    return new Subject(extractSubjectWords(subjectWord), containerWords);
   }
 
   /** Initializes the relations fields using the semantic graph. */
@@ -414,5 +406,45 @@ public class SentenceParser {
       }
     }
     return foundRelations;
+  }
+
+  private List<IndexedWord> extractSubjectWords(IndexedWord subject) {
+    List<IndexedWord> subjectWords = new ArrayList<>();
+    Queue<IndexedWord> nodeQueue = new LinkedList<>();
+    nodeQueue.add(subject);
+    subjectWords.add(subject);
+
+    while (!nodeQueue.isEmpty()) {
+      IndexedWord currentNode = nodeQueue.poll();
+      for (IndexedWord child : getChildren(currentNode)) {
+        subjectWords.add(child);
+        nodeQueue.add(child);
+      }
+    }
+    subjectWords.sort(Comparator.comparingInt(IndexedWord::index));
+    return subjectWords;
+  }
+
+  private List<IndexedWord> getChildren(IndexedWord node) {
+    List<String> relationIdentifiers =
+        Arrays.asList("compound", "advmod", "amod", "det", "nmod:poss", "nmod:of");
+    List<String> stopwords = Arrays.asList("a", "an", "the");
+
+    return semanticGraph
+        .getOutEdgesSorted(node)
+        .stream()
+        .filter(
+            edge -> {
+              GrammaticalRelation grammaticalRelation = edge.getRelation();
+              String identifier = grammaticalRelation.getShortName();
+              final String specific = grammaticalRelation.getSpecific();
+              if (specific != null) {
+                identifier += ":" + specific;
+              }
+              return relationIdentifiers.contains(identifier);
+            })
+        .map(SemanticGraphEdge::getTarget)
+        .filter(word -> !stopwords.contains(word.word().toLowerCase()))
+        .collect(Collectors.toList());
   }
 }

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsCollections4.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsCollections4.java
@@ -63,7 +63,7 @@ public class PrecisionRecallCommonsCollections4 extends AbstractPrecisionRecallT
 
   @Test
   public void testLRUMap() throws Exception {
-    test("org.apache.commons.collections4.map.LRUMap", 0.857, 0.621, 1, 0.857, 1, 0.333);
+    test("org.apache.commons.collections4.map.LRUMap", 0.892, 0.862, 1, 0.857, 1, 0.333);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsCollections4.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsCollections4.java
@@ -33,7 +33,7 @@ public class PrecisionRecallCommonsCollections4 extends AbstractPrecisionRecallT
 
   @Test
   public void testCollectionUtils() throws Exception {
-    test("org.apache.commons.collections4.CollectionUtils", 0.964, 0.870, 1, 1, 1, 0);
+    test("org.apache.commons.collections4.CollectionUtils", 0.966, 0.935, 1, 1, 1, 0);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -57,7 +57,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testRandomDataGenerator() throws Exception {
-    test("org.apache.commons.math3.random.RandomDataGenerator", 0.777, 0.5, 1, 1, 1, 1);
+    test("org.apache.commons.math3.random.RandomDataGenerator", 0.765, 0.464, 1, 1, 1, 1);
   }
 
   @Test
@@ -77,12 +77,12 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testFunctionUtils() throws Exception {
-    test("org.apache.commons.math3.analysis.FunctionUtils", 1, 0.5, 1, 1, 1, 1);
+    test("org.apache.commons.math3.analysis.FunctionUtils", 1, 0, 1, 1, 1, 1);
   }
 
   @Test
   public void testSimpsonIntegrator() throws Exception {
-    test("org.apache.commons.math3.analysis.integration.SimpsonIntegrator", 1, 0.181, 1, 0, 1, 1);
+    test("org.apache.commons.math3.analysis.integration.SimpsonIntegrator", 0.5, 0.181, 1, 0, 1, 1);
   }
 
   @Test
@@ -94,7 +94,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
   public void testIterativeLegendreGaussIntegrator() throws Exception {
     test(
         "org.apache.commons.math3.analysis.integration.IterativeLegendreGaussIntegrator",
-        1,
+        0.8,
         0.5,
         1,
         1,
@@ -136,7 +136,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testBigFraction() throws Exception {
-    test("org.apache.commons.math3.fraction.BigFraction", 0.5, 0.409, 1, 1, 1, 1);
+    test("org.apache.commons.math3.fraction.BigFraction", 0.526, 0.454, 1, 1, 1, 1);
   }
 
   @Test
@@ -171,7 +171,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testRealVector() throws Exception {
-    test("org.apache.commons.math3.linear.RealVector", 1, 0.13, 1, 1, 1, 1);
+    test("org.apache.commons.math3.linear.RealVector", 1, 0.087, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -136,7 +136,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testBigFraction() throws Exception {
-    test("org.apache.commons.math3.fraction.BigFraction", 0.474, 0.409, 1, 1, 1, 1);
+    test("org.apache.commons.math3.fraction.BigFraction", 0.5, 0.454, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallJGraphT.java
+++ b/src/test/java/org/toradocu/PrecisionRecallJGraphT.java
@@ -21,7 +21,7 @@ public class PrecisionRecallJGraphT extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testGraph() throws Exception {
-    test("org.jgrapht.Graph", 0.75, 0.333, 1, 1, 1, 0);
+    test("org.jgrapht.Graph", 1, 0.333, 1, 1, 1, 0);
   }
 
   @Test

--- a/src/test/java/org/toradocu/translator/PropositionSeriesTest.java
+++ b/src/test/java/org/toradocu/translator/PropositionSeriesTest.java
@@ -197,6 +197,17 @@ public class PropositionSeriesTest {
     assertThat(propositions.getConjunctions().get(1), is(Conjunction.AND));
   }
 
+  @Test
+  public void testIssue90() {
+    // https://github.com/albertogoffi/toradocu/issues/90
+    PropositionSeries propositions = getPropositions("Any of the specified vertices is null.");
+
+    assertThat(propositions.numberOfPropositions(), is(1));
+    assertThat(
+        propositions.getPropositions().get(0).toString(), is("(Any specified vertices, is null)"));
+    assertTrue(propositions.getConjunctions().isEmpty());
+  }
+
   private PropositionSeries getPropositions(String sentence) {
     List<SemanticGraph> semanticGraphs = StanfordParser.getSemanticGraphs(sentence);
     assertThat(semanticGraphs.size(), is(1));


### PR DESCRIPTION
Given the graph produced by the Stanford Parser, the subject extraction now uses a BFS visit of the subgraph rooted in the node marked as subject by the Stanford parser.

Fixes #90.