### PR TITLE
Manual POStagging and more improvements (old #108)

### DIFF
--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -192,9 +192,9 @@ public class ConditionTranslator {
   }
 
   private static final String INEQUALITY_NUMBER_REGEX =
-      " *((([<>=]=?)|(!=)) ?)-?([0-9]+|zero|one|two|three|four|five|six|seven|eight|nine)";
+      " *((([<>=]=?)|(!=)) ?)-?([0-9]+(?!/)(.[0-9]+)?|zero|one|two|three|four|five|six|seven|eight|nine)";
   private static final String INEQUALITY_VAR_REGEX =
-      " *((([<>=]=?)|(!=)) ?)(?!this)(([a-zA-Z0-9]+_?(?! ))+(.[a-zA-Z0-9]+(\\(*\\))?)?)";
+      " *((([<>=]=?)|(!=)) ?)(?!this)((([a-zA-Z]+([0-9]?))+_?(?! ))+(.([a-zA-Z]+([0-9]?))+(\\(*\\))?)?)";
   private static final String PLACEHOLDER_PREFIX = " INEQUALITY_";
   private static final String INEQ_INSOF = " *[an]* (instance of)"; // e.g "an instance of"
   private static final String INEQ_INSOFPROCESSED =

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -1,6 +1,9 @@
 package org.toradocu.translator;
 
+import edu.stanford.nlp.ling.HasWord;
+import edu.stanford.nlp.process.DocumentPreprocessor;
 import edu.stanford.nlp.semgraph.SemanticGraph;
+import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -17,6 +20,7 @@ import org.slf4j.LoggerFactory;
 import org.toradocu.Toradocu;
 import org.toradocu.extractor.DocumentedMethod;
 import org.toradocu.extractor.ParamTag;
+import org.toradocu.extractor.Parameter;
 import org.toradocu.extractor.Tag;
 import org.toradocu.extractor.ThrowsTag;
 
@@ -47,16 +51,46 @@ public class ConditionTranslator {
    * each sentence in the comment.
    *
    * @param comment the text of a Javadoc comment
+   * @param method the DocumentedMethod under analysis
    * @return a list of {@code PropositionSeries} objects, one for each sentence in the comment
    */
-  private static List<PropositionSeries> getPropositionSeries(String comment) {
+  private static List<PropositionSeries> getPropositionSeries(
+      String comment, DocumentedMethod method) {
     comment = addPlaceholders(comment);
     List<PropositionSeries> result = new ArrayList<>();
-    for (SemanticGraph semanticGraph : StanfordParser.getSemanticGraphs(comment)) {
+
+    for (SemanticGraph semanticGraph : customPOStag(comment, method))
       result.add(new SentenceParser(semanticGraph).getPropositionSeries());
-    }
 
     return removePlaceholders(result);
+  }
+
+  /**
+   * Before asking for the SemanticGraph to the parser, manually tag code elements as NN and
+   * inequalities placehodlers as JJ
+   *
+   * @param comment the String comment of the condition
+   * @param method the DocumentedMethod under analysis
+   * @return the list of SemanticGraphs produced by the parser
+   */
+  private static List<SemanticGraph> customPOStag(String comment, DocumentedMethod method) {
+    Iterable<List<HasWord>> hasWordComment = new DocumentPreprocessor(new StringReader(comment));
+
+    ArrayList<List<HasWord>> sentences = new ArrayList<List<HasWord>>();
+    hasWordComment.forEach(sentences::add);
+    List<SemanticGraph> result = new ArrayList<SemanticGraph>();
+    List<HasWord> codeElements = new ArrayList<HasWord>();
+    List<String> arguments = new ArrayList<String>();
+
+    for (Parameter arg : method.getParameters()) arguments.add(arg.getName());
+
+    for (List<HasWord> sentence : sentences) {
+      for (HasWord word : sentence) if (arguments.contains(word.toString())) codeElements.add(word);
+
+      result.add(CustomStanfordParser.getSemanticGraph(sentence, codeElements));
+    }
+
+    return result;
   }
 
   /**
@@ -492,7 +526,7 @@ public class ConditionTranslator {
     if (tag.getKind() == Tag.Kind.PARAM || tag.getKind() == Tag.Kind.THROWS) {
       // Identify propositions in the comment. Each sentence in the comment is parsed into a
       // PropositionSeries.
-      List<PropositionSeries> extractedPropositions = getPropositionSeries(comment);
+      List<PropositionSeries> extractedPropositions = getPropositionSeries(comment, method);
       Set<String> conditions = new LinkedHashSet<>();
       // Identify Java code elements in propositions.
       for (PropositionSeries propositions : extractedPropositions) {
@@ -616,7 +650,7 @@ public class ConditionTranslator {
     // PropositionSeries.
 
     text = removeInitial(text, "if");
-    List<PropositionSeries> extractedPropositions = getPropositionSeries(text);
+    List<PropositionSeries> extractedPropositions = getPropositionSeries(text, method);
     Set<String> conditions = new LinkedHashSet<>();
     // Identify Java code elements in propositions.
     for (PropositionSeries propositions : extractedPropositions) {

--- a/src/main/java/org/toradocu/translator/ConditionTranslator.java
+++ b/src/main/java/org/toradocu/translator/ConditionTranslator.java
@@ -160,7 +160,7 @@ public class ConditionTranslator {
   private static final String INEQUALITY_NUMBER_REGEX =
       " *((([<>=]=?)|(!=)) ?)-?([0-9]+|zero|one|two|three|four|five|six|seven|eight|nine)";
   private static final String INEQUALITY_VAR_REGEX =
-      " *((([<>=]=?)|(!=)) ?)(?!this)(([a-zA-Z]+_?)+(.[a-zA-Z0-9]+(\\(*\\))?)?)";
+      " *((([<>=]=?)|(!=)) ?)(?!this)(([a-zA-Z0-9]+_?(?! ))+(.[a-zA-Z0-9]+(\\(*\\))?)?)";
   private static final String PLACEHOLDER_PREFIX = " INEQUALITY_";
   private static final String INEQ_INSOF = " *[an]* (instance of)"; // e.g "an instance of"
   private static final String INEQ_INSOFPROCESSED =

--- a/src/main/java/org/toradocu/translator/CustomStanfordParser.java
+++ b/src/main/java/org/toradocu/translator/CustomStanfordParser.java
@@ -1,0 +1,34 @@
+package org.toradocu.translator;
+
+import edu.stanford.nlp.ling.HasWord;
+import edu.stanford.nlp.parser.lexparser.LexicalizedParser;
+import edu.stanford.nlp.semgraph.SemanticGraph;
+import edu.stanford.nlp.trees.GrammaticalStructure;
+import edu.stanford.nlp.trees.GrammaticalStructureFactory;
+import edu.stanford.nlp.trees.Tree;
+import edu.stanford.nlp.trees.TreebankLanguagePack;
+import java.util.List;
+
+public class CustomStanfordParser {
+
+  private static final LexicalizedParser LEXICALIZED_PARSER;
+  private static final GrammaticalStructureFactory GSF;
+
+  static {
+    LEXICALIZED_PARSER = LexicalizedParser.loadModel();
+    TreebankLanguagePack tlp =
+        LEXICALIZED_PARSER.treebankLanguagePack(); // a PennTreebankLanguagePack for English
+    GSF =
+        tlp.supportsGrammaticalStructures()
+            ? tlp.grammaticalStructureFactory()
+            : null; //FIXME This leads to a NullPointerException. Better to throw a meaningful exception here!
+  }
+
+  public static SemanticGraph getSemanticGraph(List<HasWord> sentence, List<HasWord> codeElements) {
+    Tree tree =
+        LEXICALIZED_PARSER.parse(
+            new POSTagger().tagWords(sentence, codeElements)); // parse the sentence
+    GrammaticalStructure gs = GSF.newGrammaticalStructure(tree);
+    return new SemanticGraph(gs.typedDependenciesCCprocessed()); // build the dependency graph
+  }
+}

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -298,11 +298,12 @@ class Matcher {
     java.util.regex.Matcher inequalityNumber =
         Pattern.compile(
                 verbs
-                    + "(<=|>=|<|>|!=|==|=)? ?(-?([0-9]+|zero|one|two|three|four|five|six|seven|eight|nine))")
+                    + "(<=|>=|<|>|!=|==|=)? ?(-?([0-9]+(.[0-9]+)?|zero|one|two|three|four|five|six|seven|eight|nine))")
             .matcher(predicate);
 
     java.util.regex.Matcher inequalityVar =
-        Pattern.compile(verbs + "(<=|>=|<|>|!=|==|=) ?(([a-zA-Z0-9]+_?)+)").matcher(predicate);
+        Pattern.compile(verbs + "(<=|>=|<|>|!=|==|=) ?((([a-zA-Z]+[0-9]?)+_?)+)")
+            .matcher(predicate);
 
     java.util.regex.Matcher instanceOf = Pattern.compile("(instanceof) (.*)").matcher(predicate);
 
@@ -369,19 +370,30 @@ class Matcher {
       }
     } else if (inequalityNumber.find()) {
       // Get the number from the last group of the regular expression.
-      String numberString = inequalityNumber.group(inequalityNumber.groupCount());
+      String numberString = inequalityNumber.group(3);
       // Get the symbol from the regular expression.
       String relation = inequalityNumber.group(2);
       String numberWord = numberWordToDigit(numberString);
-      int number =
-          (!numberWord.equals(""))
-              ? number = Integer.parseInt(numberWord)
-              : Integer.parseInt(numberString);
+
+      int intNumber = 0;
+      float floatNumber = 0;
+      boolean isIntNumber = false;
+
+      if (!numberString.contains(".")) { //the number is an int
+        intNumber =
+            (!numberWord.equals(""))
+                ? intNumber = Integer.parseInt(numberWord)
+                : Integer.parseInt(numberString);
+
+        isIntNumber = true;
+      } else {
+        floatNumber = Float.parseFloat(numberString);
+      }
       // relation is null in predicates without inequalities. For example "is 0".
       if (relation == null || relation.equals("=")) {
-        predicateTranslation = "==" + number;
+        predicateTranslation = (isIntNumber) ? ("==" + intNumber) : ("==" + floatNumber);
       } else {
-        predicateTranslation = relation + number;
+        predicateTranslation = (isIntNumber) ? (relation + intNumber) : (relation + floatNumber);
       }
     } else if (inequalityVar.find()) {
       // Get the variable from the last group of the regular expression.

--- a/src/main/java/org/toradocu/translator/POSTagger.java
+++ b/src/main/java/org/toradocu/translator/POSTagger.java
@@ -1,0 +1,35 @@
+package org.toradocu.translator;
+
+import edu.stanford.nlp.ling.HasWord;
+import edu.stanford.nlp.ling.TaggedWord;
+import java.util.ArrayList;
+import java.util.List;
+
+public class POSTagger {
+
+  /**
+   * This is a custom POS tagger to be used by the Stanford Parser. The purpose is tagging words in
+   * the comment in case we already know their right POS tag. Up to now, this is useful for
+   * inequalities placeholder (tagged ad JJ) and code elements (tagged as NN). This way, the
+   * Stanford Parser will take in input a partially tagged sentence, and will adapt its tagging to
+   * our previous one.
+   *
+   * @param sentence the original sentence to tag, i.e. the comment
+   * @param codeElements list of the words in the sentence that are code elements
+   * @return the partially tagged sentence
+   */
+  public List<TaggedWord> tagWords(List<HasWord> sentence, List<HasWord> codeElements) {
+    List<TaggedWord> taggedSentence = new ArrayList<>(sentence.size());
+    for (HasWord word : sentence) {
+      String wordString = word.toString();
+      TaggedWord taggedWord = new TaggedWord(wordString);
+      if (wordString.contains("INEQUALITY") && taggedWord.tag() == null)
+        taggedSentence.add(new TaggedWord(wordString, "JJ"));
+      else if (codeElements.contains(word) && taggedWord.tag() == null)
+        taggedSentence.add(new TaggedWord(wordString, "NN"));
+      else taggedSentence.add(taggedWord);
+    }
+
+    return taggedSentence;
+  }
+}

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsCollections4.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsCollections4.java
@@ -68,7 +68,7 @@ public class PrecisionRecallCommonsCollections4 extends AbstractPrecisionRecallT
 
   @Test
   public void testAllPredicate() throws Exception {
-    test("org.apache.commons.collections4.functors.AllPredicate", 1, 0.75, 0.333, 0.333, 1, 1);
+    test("org.apache.commons.collections4.functors.AllPredicate", 1, 0.75, 0.666, 0.666, 1, 1);
   }
 
   @Test
@@ -78,6 +78,6 @@ public class PrecisionRecallCommonsCollections4 extends AbstractPrecisionRecallT
 
   @Test
   public void testAnyPredicate() throws Exception {
-    test("org.apache.commons.collections4.functors.AnyPredicate", 1, 0.75, 0.333, 0.333, 1, 1);
+    test("org.apache.commons.collections4.functors.AnyPredicate", 1, 0.75, 1, 1, 1, 1);
   }
 }

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -22,14 +22,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testUnivariateSolverUtils() throws Exception {
-    test(
-        "org.apache.commons.math3.analysis.solvers.UnivariateSolverUtils",
-        0.889,
-        0.889,
-        1,
-        0,
-        1,
-        1);
+    test("org.apache.commons.math3.analysis.solvers.UnivariateSolverUtils", 1, 1, 1, 0, 1, 1);
   }
 
   @Test
@@ -44,7 +37,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testAdaptiveStepsizeIntegrator() throws Exception {
-    test("org.apache.commons.math3.ode.nonstiff.AdaptiveStepsizeIntegrator", 1, 1, 1, 1, 1, 1);
+    test("org.apache.commons.math3.ode.nonstiff.AdaptiveStepsizeIntegrator", 1, 1, 1, 0.8, 1, 1);
   }
 
   @Test
@@ -54,7 +47,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testBitsStreamGenerator() throws Exception {
-    test("org.apache.commons.math3.random.BitsStreamGenerator", 0.5, 0.5, 1, 0.8, 1, 1);
+    test("org.apache.commons.math3.random.BitsStreamGenerator", 1, 0.75, 1, 0.8, 1, 1);
   }
 
   @Test
@@ -64,12 +57,12 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testRandomDataGenerator() throws Exception {
-    test("org.apache.commons.math3.random.RandomDataGenerator", 0.808, 0.75, 1, 1, 1, 1);
+    test("org.apache.commons.math3.random.RandomDataGenerator", 1, 0.928, 1, 1, 1, 1);
   }
 
   @Test
   public void testArithmeticUtils() throws Exception {
-    test("org.apache.commons.math3.util.ArithmeticUtils", 1, 0.631, 1, 0, 1, 1);
+    test("org.apache.commons.math3.util.ArithmeticUtils", 1, 0.947, 1, 0.666, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallGraphStream.java
+++ b/src/test/java/org/toradocu/PrecisionRecallGraphStream.java
@@ -15,11 +15,11 @@ public class PrecisionRecallGraphStream extends AbstractPrecisionRecallTestSuite
 
   @Test
   public void testSingleGraph() throws Exception {
-    test("org.graphstream.graph.implementations.SingleGraph", 0, 0, 0.333, 0.333, 1, 0);
+    test("org.graphstream.graph.implementations.SingleGraph", 0, 0, 0.667, 0.333, 1, 0);
   }
 
   @Test
   public void testMultiGraph() throws Exception {
-    test("org.graphstream.graph.implementations.MultiGraph", 0, 0, 0.333, 0.333, 1, 0);
+    test("org.graphstream.graph.implementations.MultiGraph", 0, 0, 0.667, 0.333, 1, 0);
   }
 }

--- a/src/test/java/org/toradocu/PrecisionRecallGuava19.java
+++ b/src/test/java/org/toradocu/PrecisionRecallGuava19.java
@@ -50,7 +50,7 @@ public class PrecisionRecallGuava19 extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testBloomFilter() throws Exception {
-    test("com.google.common.hash.BloomFilter", 0.5, 0.5, 0.777, 0.777, 1, 1);
+    test("com.google.common.hash.BloomFilter", 0.5, 0.5, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.util.ArithmeticUtils_goal.json
+++ b/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.util.ArithmeticUtils_goal.json
@@ -1451,7 +1451,7 @@
       },
       {
         "comment": "Exponent (must be positive or zero).",
-        "condition": "args[1]>=0",
+        "condition": "args[1]>0||args[1]==0",
         "kind": "PARAM",
         "parameter": {
           "name": "e",
@@ -1544,7 +1544,7 @@
       },
       {
         "comment": "Exponent (must be positive or zero).",
-        "condition": "args[1]>=0",
+        "condition": "args[1]>0||args[1]==0",
         "kind": "PARAM",
         "parameter": {
           "name": "e",
@@ -1626,7 +1626,7 @@
       },
       {
         "comment": "Exponent (must be positive or zero).",
-        "condition": "args[1]>=0",
+        "condition": "args[1]>0||args[1]==0",
         "kind": "PARAM",
         "parameter": {
           "name": "e",
@@ -1719,7 +1719,7 @@
       },
       {
         "comment": "Exponent (must be positive or zero).",
-        "condition": "args[1]>=0",
+        "condition": "args[1]>0||args[1]==0",
         "kind": "PARAM",
         "parameter": {
           "name": "e",
@@ -1801,7 +1801,7 @@
       },
       {
         "comment": "Exponent (must be positive or zero).",
-        "condition": "args[1]>=0",
+        "condition": "args[1]>0||args[1]==0",
         "kind": "PARAM",
         "parameter": {
           "name": "e",
@@ -1883,7 +1883,7 @@
       },
       {
         "comment": "Exponent (must be positive or zero).",
-        "condition": "args[1]>=0",
+        "condition": "args[1]>0||args[1]==0",
         "kind": "PARAM",
         "parameter": {
           "name": "e",
@@ -1965,7 +1965,7 @@
       },
       {
         "comment": "Exponent (must be positive or zero).",
-        "condition": "args[1]>=0",
+        "condition": "args[1]>0||args[1]==0",
         "kind": "PARAM",
         "parameter": {
           "name": "e",

--- a/src/test/resources/goal-output/guava-19.0/com.google.common.hash.BloomFilter_goal.json
+++ b/src/test/resources/goal-output/guava-19.0/com.google.common.hash.BloomFilter_goal.json
@@ -389,7 +389,7 @@
       },
       {
         "comment": "the desired false positive probability (must be positive and less than 1.0)",
-        "condition": "args[2]>0 || args[2]<1.0",
+        "condition": "args[2]>0 && args[2]<1.0",
         "kind": "PARAM",
         "parameter": {
           "name": "fpp",
@@ -478,7 +478,7 @@
       },
       {
         "comment": "the desired false positive probability (must be positive and less than 1.0)",
-        "condition": "args[2]>0 || args[2]<1.0",
+        "condition": "args[2]>0 && args[2]<1.0",
         "kind": "PARAM",
         "parameter": {
           "name": "fpp",


### PR DESCRIPTION
This request includes:

- the code for the manual POStagging of code elements (as nouns) and inequalities' placeholders (as adjectives)
- some other small improvements: more precise variable comparison and support for floating point numbers (to translate conditions like `args[0]>1.0`)
- fix in preicsion/recall test suite and in some goal files