### PR TITLE
Add new parameter identifiers and improve support for comments on arrays size

### DIFF
--- a/src/main/java/org/toradocu/translator/JavaElementsCollector.java
+++ b/src/main/java/org/toradocu/translator/JavaElementsCollector.java
@@ -88,14 +88,14 @@ public class JavaElementsCollector {
       paramIndex++;
     }
 
+    // Select only valid identifiers for the parameters, i.e. the unique ones (count in map is 0)
     for (ParameterCodeElement p : params) {
-      Set<String> ids = ((ParameterCodeElement) p).getOtherIdentifiers();
+      Set<String> ids = p.getOtherIdentifiers();
       for (Entry<String, Integer> countId : countIds.entrySet()) {
-        if (ids.contains(countId.getKey()) && countId.getValue() > 0) {
-          ((ParameterCodeElement) p).removeIdentifier(countId.getKey());
-        }
+        String identifier = countId.getKey();
+        if (ids.contains(identifier) && countId.getValue() > 0) p.removeIdentifier(identifier);
       }
-      ((ParameterCodeElement) p).mergeIdentifiers();
+      p.mergeIdentifiers();
     }
 
     // Add methods of the target class (all but the method corresponding to documentedMethod).
@@ -122,6 +122,14 @@ public class JavaElementsCollector {
     return collectedElements;
   }
 
+  /**
+   * For the parameter in input, find its param tag in the method's Javadoc and produce the
+   * SemanticGraphs of the comment. For every graph, keep the root as identifier.
+   *
+   * @param method the DocumentedMethod which the parameter belongs to
+   * @param param the parameter
+   * @return the extracted ids
+   */
   private static Set<String> extractIdsFromParams(DocumentedMethod method, String param) {
     Set<ParamTag> paramTags = method.paramTags();
     Set<String> ids = new HashSet<String>();

--- a/src/main/java/org/toradocu/translator/JavaElementsCollector.java
+++ b/src/main/java/org/toradocu/translator/JavaElementsCollector.java
@@ -126,8 +126,8 @@ public class JavaElementsCollector {
     Set<ParamTag> paramTags = method.paramTags();
     Set<String> ids = new HashSet<String>();
     for (ParamTag pt : paramTags) {
-      String bohboh = pt.parameter().getName();
-      if (bohboh.equals(param)) {
+      String paramName = pt.parameter().getName();
+      if (paramName.equals(param)) {
         List<SemanticGraph> sgs = StanfordParser.getSemanticGraphs(pt.getComment());
         for (SemanticGraph sg : sgs) ids.add(sg.getFirstRoot().word());
       }

--- a/src/main/java/org/toradocu/translator/JavaElementsCollector.java
+++ b/src/main/java/org/toradocu/translator/JavaElementsCollector.java
@@ -61,26 +61,20 @@ public class JavaElementsCollector {
       parameters.remove(0);
     }
 
-    HashMap<String, Integer> countIds = new HashMap<String, Integer>();
-    Set<ParameterCodeElement> params = new HashSet<ParameterCodeElement>();
+    HashMap<String, Integer> countIds = new HashMap<>();
+    Set<ParameterCodeElement> params = new HashSet<>();
 
     for (java.lang.reflect.Parameter par : parameters) {
+      String paramName = documentedMethod.getParameters().get(paramIndex).getName();
       // Extract identifiers from param comment
-      Set<String> ids = new HashSet<String>();
-      //      if(documentedMethod.getParameters().get(paramIndex).getName().length()==1)
-      ids =
-          extractIdsFromParams(
-              documentedMethod, documentedMethod.getParameters().get(paramIndex).getName());
+      Set<String> ids = extractIdsFromParams(documentedMethod, paramName);
 
       for (String id : ids) {
-        Integer oldValue = countIds.get(id);
-        if (oldValue == null) countIds.put(id, 0);
-        else countIds.put(id, ++oldValue);
+        Integer oldValue = countIds.getOrDefault(id, -1);
+        countIds.put(id, ++oldValue);
       }
 
-      ParameterCodeElement p =
-          new ParameterCodeElement(
-              par, documentedMethod.getParameters().get(paramIndex).getName(), paramIndex, ids);
+      ParameterCodeElement p = new ParameterCodeElement(par, paramName, paramIndex, ids);
       collectedElements.add(p);
       params.add(p);
 
@@ -88,6 +82,8 @@ public class JavaElementsCollector {
       paramIndex++;
     }
 
+    // TODO Create a parameter code element directly with unique identifiers, thus removing
+    // mergeIdentifiers() and related methods in ParameterCodeElement.
     // Select only valid identifiers for the parameters, i.e. the unique ones (count in map is 0)
     for (ParameterCodeElement p : params) {
       Set<String> ids = p.getOtherIdentifiers();
@@ -132,7 +128,7 @@ public class JavaElementsCollector {
    */
   private static Set<String> extractIdsFromParams(DocumentedMethod method, String param) {
     Set<ParamTag> paramTags = method.paramTags();
-    Set<String> ids = new HashSet<String>();
+    Set<String> ids = new HashSet<>();
     for (ParamTag pt : paramTags) {
       String paramName = pt.parameter().getName();
       if (paramName.equals(param)) {

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -111,12 +111,19 @@ class Matcher {
 
     // Special case to handle predicates about arrays' length. We need a more general solution.
     if (subject.getJavaCodeElement().toString().contains("[]")) {
-      final java.util.regex.Matcher lengthPatter =
+      final java.util.regex.Matcher lengthPattern =
           Pattern.compile("has length ([0-9]+|zero)").matcher(predicate);
-      if (lengthPatter.find()) {
-        final String lengthString = lengthPatter.group(1);
+      if (lengthPattern.find()) {
+        final String lengthString = lengthPattern.group(1);
         final int length = lengthString.equals("zero") ? 0 : Integer.parseInt(lengthString);
         return subject.getJavaExpression() + ".length==" + length;
+      }
+      final java.util.regex.Matcher numberPattern =
+          Pattern.compile("([<>=]=?|(!=)) ?([0-9]+|zero)").matcher(predicate);
+      if (numberPattern.find()) {
+        final String lengthString = numberPattern.group(3);
+        final int length = lengthString.equals("zero") ? 0 : Integer.parseInt(lengthString);
+        return subject.getJavaExpression() + ".length" + numberPattern.group(1) + length;
       }
 
       // "zero-length" special case handling.

--- a/src/main/java/org/toradocu/translator/ParameterCodeElement.java
+++ b/src/main/java/org/toradocu/translator/ParameterCodeElement.java
@@ -1,6 +1,7 @@
 package org.toradocu.translator;
 
 import java.lang.reflect.Parameter;
+import java.util.Set;
 import java.util.StringJoiner;
 
 /**
@@ -19,8 +20,9 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
    * @param parameter the backing parameter that this code element identifies
    * @param name the name of the parameter
    * @param index the 0-based index of the parameter in the parameter list of its associated method
+   * @param ids the alternative IDs extracted from the param comment
    */
-  public ParameterCodeElement(Parameter parameter, String name, int index) {
+  public ParameterCodeElement(Parameter parameter, String name, int index, Set<String> ids) {
     super(parameter);
     this.index = index;
 
@@ -31,6 +33,7 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
     addIdentifier(name);
     addIdentifier(parameter.getType().getSimpleName() + " " + name);
     addIdentifier(name + " " + parameter.getType().getSimpleName());
+    for (String id : ids) addIdentifier(id);
     // Add name identifier splitting camel case name into different words. We consider as
     // identifier the single words, and a string composed by the words separated by whitespace.
     StringJoiner joiner = new StringJoiner(" ");

--- a/src/main/java/org/toradocu/translator/ParameterCodeElement.java
+++ b/src/main/java/org/toradocu/translator/ParameterCodeElement.java
@@ -14,6 +14,8 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
   /** The 0-based index of this parameter in its associated method's parameter list. */
   private int index;
 
+  /** Additional identifiers coming directly from param comments. */
+  private Set<String> otherIdentifiers;
   /**
    * Constructs and initializes a {@code ParameterCodeElement} that identifies the given parameter.
    *
@@ -25,6 +27,7 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
   public ParameterCodeElement(Parameter parameter, String name, int index, Set<String> ids) {
     super(parameter);
     this.index = index;
+    this.otherIdentifiers = ids;
 
     // Add name identifiers.
     addIdentifier("parameter");
@@ -33,7 +36,6 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
     addIdentifier(name);
     addIdentifier(parameter.getType().getSimpleName() + " " + name);
     addIdentifier(name + " " + parameter.getType().getSimpleName());
-    for (String id : ids) addIdentifier(id);
     // Add name identifier splitting camel case name into different words. We consider as
     // identifier the single words, and a string composed by the words separated by whitespace.
     StringJoiner joiner = new StringJoiner(" ");
@@ -56,6 +58,27 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
     }
   }
 
+  /**
+   * Returns a list of strings that identify this code element.
+   *
+   * @return a list of strings that identify this code element
+   */
+  public Set<String> getOtherIdentifiers() {
+    return otherIdentifiers;
+  }
+
+  /**
+   * Remove a string identifier for the code element that this object represents.
+   *
+   * @param identifier a string that identifies this code element
+   */
+  public void removeIdentifier(String identifier) {
+    otherIdentifiers.remove(identifier);
+  }
+
+  public void mergeIdentifiers() {
+    getIdentifiers().addAll(otherIdentifiers);
+  }
   /**
    * Builds and returns the Java expression representation of this parameter code element. The
    * returned string is formatted as "args[i]" where i is the index of this parameter in a parameter

--- a/src/main/java/org/toradocu/translator/ParameterCodeElement.java
+++ b/src/main/java/org/toradocu/translator/ParameterCodeElement.java
@@ -15,19 +15,20 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
   private int index;
 
   /** Additional identifiers coming directly from param comments. */
-  private Set<String> otherIdentifiers;
+  private Set<String> extractedIdentifiers;
   /**
    * Constructs and initializes a {@code ParameterCodeElement} that identifies the given parameter.
    *
    * @param parameter the backing parameter that this code element identifies
    * @param name the name of the parameter
    * @param index the 0-based index of the parameter in the parameter list of its associated method
-   * @param ids the alternative IDs extracted from the param comment
+   * @param extractedIds the additional IDs extracted from the param comment
    */
-  public ParameterCodeElement(Parameter parameter, String name, int index, Set<String> ids) {
+  public ParameterCodeElement(
+      Parameter parameter, String name, int index, Set<String> extractedIds) {
     super(parameter);
     this.index = index;
-    this.otherIdentifiers = ids;
+    this.extractedIdentifiers = extractedIds;
 
     // Add name identifiers.
     addIdentifier("parameter");
@@ -59,25 +60,26 @@ public class ParameterCodeElement extends CodeElement<Parameter> {
   }
 
   /**
-   * Returns a list of strings that identify this code element.
+   * Returns the additional identifiers extractedIdentifiers.
    *
    * @return a list of strings that identify this code element
    */
   public Set<String> getOtherIdentifiers() {
-    return otherIdentifiers;
+    return extractedIdentifiers;
   }
 
   /**
-   * Remove a string identifier for the code element that this object represents.
+   * Remove a string identifier from extractedIdentifiers.
    *
    * @param identifier a string that identifies this code element
    */
   public void removeIdentifier(String identifier) {
-    otherIdentifiers.remove(identifier);
+    extractedIdentifiers.remove(identifier);
   }
 
+  /** Merge the default identifiers with the additional ones extractedIdentifiers. */
   public void mergeIdentifiers() {
-    getIdentifiers().addAll(otherIdentifiers);
+    getIdentifiers().addAll(extractedIdentifiers);
   }
   /**
    * Builds and returns the Java expression representation of this parameter code element. The

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -111,7 +111,8 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testLinearInterpolator() throws Exception {
-    test("org.apache.commons.math3.analysis.interpolation.LinearInterpolator", 1, 0, 1, 1, 1, 1);
+    test(
+        "org.apache.commons.math3.analysis.interpolation.LinearInterpolator", 1, 0.333, 1, 1, 1, 1);
   }
 
   @Test
@@ -186,7 +187,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
     test(
         "org.apache.commons.math3.analysis.interpolation.DividedDifferenceInterpolator",
         1,
-        0,
+        0.4,
         1,
         1,
         1,

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -27,7 +27,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testComplex() throws Exception {
-    test("org.apache.commons.math3.complex.Complex", 0.583, 0.583, 1, 1, 1, 1);
+    test("org.apache.commons.math3.complex.Complex", 0.5, 0.5, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/PrecisionRecallCommonsMath3.java
@@ -27,7 +27,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testComplex() throws Exception {
-    test("org.apache.commons.math3.complex.Complex", 0.5, 0.5, 1, 1, 1, 1);
+    test("org.apache.commons.math3.complex.Complex", 0.583, 0.583, 1, 1, 1, 1);
   }
 
   @Test
@@ -42,7 +42,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testPrimes() throws Exception {
-    test("org.apache.commons.math3.primes.Primes", 1, 1, 1, 1, 1, 1);
+    test("org.apache.commons.math3.primes.Primes", 1, 1, 1, 1, 0, 0);
   }
 
   @Test
@@ -57,7 +57,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testRandomDataGenerator() throws Exception {
-    test("org.apache.commons.math3.random.RandomDataGenerator", 1, 0.928, 1, 1, 1, 1);
+    test("org.apache.commons.math3.random.RandomDataGenerator", 1, 0.964, 1, 1, 1, 1);
   }
 
   @Test
@@ -148,7 +148,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testFraction() throws Exception {
-    test("org.apache.commons.math3.fraction.Fraction", 0.462, 0.429, 1, 1, 1, 1);
+    test("org.apache.commons.math3.fraction.Fraction", 0.5, 0.5, 1, 1, 1, 1);
   }
 
   @Test
@@ -178,7 +178,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testRealVector() throws Exception {
-    test("org.apache.commons.math3.linear.RealVector", 1, 0.304, 1, 1, 1, 1);
+    test("org.apache.commons.math3.linear.RealVector", 1, 0.348, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/PrecisionRecallJGraphT.java
+++ b/src/test/java/org/toradocu/PrecisionRecallJGraphT.java
@@ -16,12 +16,12 @@ public class PrecisionRecallJGraphT extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testAbstractGraph() throws Exception {
-    test("org.jgrapht.graph.AbstractGraph", 1, 0.5, 1, 1, 1, 0);
+    test("org.jgrapht.graph.AbstractGraph", 1, 0.75, 1, 1, 1, 0);
   }
 
   @Test
   public void testGraph() throws Exception {
-    test("org.jgrapht.Graph", 1, 0.333, 1, 1, 1, 0);
+    test("org.jgrapht.Graph", 1, 0.444, 1, 1, 1, 0);
   }
 
   @Test
@@ -51,12 +51,12 @@ public class PrecisionRecallJGraphT extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testAbstractPathElementList() throws Exception {
-    test("org.jgrapht.alg.AbstractPathElementList", 1, 0.666, 1, 1, 1, 1);
+    test("org.jgrapht.alg.AbstractPathElementList", 1, 0.8, 1, 1, 1, 1);
   }
 
   @Test
   public void testDirectedAcyclicGraph() throws Exception {
-    test("org.jgrapht.experimental.dag.DirectedAcyclicGraph", 1, 0.428, 1, 1, 1, 1);
+    test("org.jgrapht.experimental.dag.DirectedAcyclicGraph", 1, 0.714, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.complex.Complex_goal.json
+++ b/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.complex.Complex_goal.json
@@ -429,7 +429,7 @@
           "this"
         ],
         "comment": "if this is zero",
-        "condition": "target.abs()==0",
+        "condition": "target==0",
         "exception": {
           "isArray": false,
           "name": "MathArithmeticException",

--- a/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.complex.Complex_goal.json
+++ b/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.complex.Complex_goal.json
@@ -429,7 +429,7 @@
           "this"
         ],
         "comment": "if this is zero",
-        "condition": "target==0",
+        "condition": "target.abs()==0",
         "exception": {
           "isArray": false,
           "name": "MathArithmeticException",

--- a/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.primes.Primes_goal.json
+++ b/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.primes.Primes_goal.json
@@ -48,7 +48,7 @@
     ],
     "returnTag": {
       "comment": "true if n is prime. (All numbers < 2 return false).",
-      "condition": "org.apache.commons.math3.primes.Primes.isPrime(args[0]) ? result == true",
+      "condition": "(args[0]<2) ? result==false",
       "kind": "RETURN"
     },
     "returnType": {

--- a/src/test/resources/goal-output/jgrapht-core-0.9.2/org.jgrapht.alg.AbstractPathElementList_goal.json
+++ b/src/test/resources/goal-output/jgrapht-core-0.9.2/org.jgrapht.alg.AbstractPathElementList_goal.json
@@ -181,7 +181,7 @@
       },
       {
         "comment": "if pathElement is not empty.",
-        "condition": "args[2].getPrevEdge()!=null",
+        "condition": "",
         "exception": {
           "isArray": false,
           "name": "IllegalArgumentException",


### PR DESCRIPTION
This request includes:

-  extraction of additional identifiers for parameters from the param tags comment, useful to retrieve the right subjects
- support to translate more conditions about arrays size, as "length less than 2"
- correction of some goal files