### PR TITLE
Add more tests for the Javadoc extractor component

### DIFF
--- a/src/test/resources/example/AClass.java
+++ b/src/test/resources/example/AClass.java
@@ -3,6 +3,7 @@ package example;
 import example.annotation.NotNull;
 import example.annotation.Nullable;
 import example.exception.AnException;
+import java.util.Collection;
 
 public class AClass {
 
@@ -36,4 +37,20 @@ public class AClass {
 
   /** A private method. */
   private void aPrivateMethod() {}
+
+  /**
+   * @param name a String
+   * @param type a Class
+   */
+  public <T extends Class> void callFriend(String name, Class<T> type) {}
+
+  /**
+   * @param a an array
+   * @param c a Collection
+   */
+  public <T> void fromArrayToCollection(@NotNull T[] a, @NotNull Collection<T> c) {
+    for (T o : a) {
+      c.add(o); // Correct
+    }
+  }
 }


### PR DESCRIPTION
Added a few classes in the AClass class in order to check the behavior of the JavadocExtractor.

During this session of test, the method JavadocExtractor#extract throws an AssertionError exception due to the length of the matches variable, that means Toradocu can't match reflection with source types correctly.

Here's the log:

java.lang.AssertionError: Cannot find reflection executable member corresponding to fromArrayToCollection(T[], Collection)
	at org.toradocu.extractor.JavadocExtractor.mapExecutables(JavadocExtractor.java:280)
	at org.toradocu.extractor.JavadocExtractor.extract(JavadocExtractor.java:61)
	at org.toradocu.extractor.JavadocExtractorTest.runJavadocExtractor(JavadocExtractorTest.java:208)
	at org.toradocu.extractor.JavadocExtractorTest.setUp(JavadocExtractorTest.java:45)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:24)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.eclipse.jdt.internal.junit4.runner.JUnit4TestReference.run(JUnit4TestReference.java:86)
	at org.eclipse.jdt.internal.junit.runner.TestExecution.run(TestExecution.java:38)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:459)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.runTests(RemoteTestRunner.java:678)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.run(RemoteTestRunner.java:382)
	at org.eclipse.jdt.internal.junit.runner.RemoteTestRunner.main(RemoteTestRunner.java:192)

In order to reproduce the fail, just execute the JavadocExtractorTest with the new AClass.