### PR TITLE
Introduce translation of "whether"

### DIFF
--- a/src/main/java/org/toradocu/translator/preprocess/NormalizeWhether.java
+++ b/src/main/java/org/toradocu/translator/preprocess/NormalizeWhether.java
@@ -1,0 +1,22 @@
+package org.toradocu.translator.preprocess;
+
+import org.toradocu.extractor.BlockTag;
+import org.toradocu.extractor.DocumentedExecutable;
+
+public class NormalizeWhether implements PreprocessingPhase {
+
+  private static String normalizeComment(String comment, DocumentedExecutable method) {
+    if (comment.toLowerCase().startsWith("whether")) {
+      String preComment = "True if";
+      String postComment = ", false otherwise";
+      comment = comment.replaceFirst("whether", preComment) + postComment;
+    }
+
+    return comment;
+  }
+
+  @Override
+  public String run(BlockTag tag, DocumentedExecutable excMember) {
+    return normalizeComment(tag.getComment().getText(), excMember);
+  }
+}

--- a/src/main/java/org/toradocu/translator/preprocess/PreprocessorFactory.java
+++ b/src/main/java/org/toradocu/translator/preprocess/PreprocessorFactory.java
@@ -33,6 +33,7 @@ public class PreprocessorFactory {
         phases.add(new NormalizeIfs());
         phases.add(new NormalizeNonNullNonEmpty());
         phases.add(new NormalizeIt());
+        phases.add(new NormalizeWhether());
         break;
     }
 

--- a/src/test/java/org/toradocu/accuracy/random/AccuracyRandomPlumeLib.java
+++ b/src/test/java/org/toradocu/accuracy/random/AccuracyRandomPlumeLib.java
@@ -16,7 +16,7 @@ public class AccuracyRandomPlumeLib extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testFuzzyFloat() throws Exception {
-    test("plume.FuzzyFloat", 1, 1, 1, 1, 0, 0);
+    test("plume.FuzzyFloat", 1, 1, 1, 1, 1, 0.8);
   }
 
   @Test

--- a/src/test/resources/goal-output/random/plume-lib-1.1.0/plume.FuzzyFloat_goal.json
+++ b/src/test/resources/goal-output/random/plume-lib-1.1.0/plume.FuzzyFloat_goal.json
@@ -192,7 +192,7 @@
     "returnTag": {
       "comment": "whether d1 and d2 are non-equal.",
       "kind": "RETURN",
-      "condition": ""
+      "condition": "args[0]!=args[1] ? result==true:result==false"
     },
     "throwsTags": []
   },
@@ -260,7 +260,7 @@
     "returnTag": {
       "comment": "whether d1 < d2.",
       "kind": "RETURN",
-      "condition": "args[0]<args[1] ? result==true"
+      "condition": "args[0]<args[1] ? result==true:result==false"
     },
     "throwsTags": []
   },
@@ -328,7 +328,7 @@
     "returnTag": {
       "comment": "whether d1 <= d2.",
       "kind": "RETURN",
-      "condition": "args[0]<=args[1] ? result==true"
+      "condition": "args[0]<=args[1] ? result==true:result==false"
     },
     "throwsTags": []
   },
@@ -396,7 +396,7 @@
     "returnTag": {
       "comment": "whether d1 > d2.",
       "kind": "RETURN",
-      "condition": "args[0]>args[1] ? result==true"
+      "condition": "args[0]>args[1] ? result==true:result==false"
     },
     "throwsTags": []
   },
@@ -464,7 +464,7 @@
     "returnTag": {
       "comment": "whether d1 > d2.",
       "kind": "RETURN",
-      "condition": "args[0]>args[1] ? result==true"
+      "condition": "args[0]>args[1] ? result==true:result==false"
     },
     "throwsTags": []
   },


### PR DESCRIPTION
- Add new pre-processing phase to correctly translate comments starting with "whether". 
- Fix one goal file and precision/recall values from PlumeLib (random test suite)