### PR TITLE
Modify handling of inline code tags

### DIFF
--- a/src/main/java/org/toradocu/extractor/Comment.java
+++ b/src/main/java/org/toradocu/extractor/Comment.java
@@ -1,9 +1,6 @@
 package org.toradocu.extractor;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -23,9 +20,11 @@ public final class Comment {
   /**
    * Words marked with {@literal @code} tag in comment text. With "word" we mean a single String (in
    * case of a whole sentence tagged as code, each word is stored separately). We do not retain
-   * symbols and numbers. Words are mapped with a list of integers, that stores the occurrences
-   * which are tagged as code. This is necessary to keep a consistent track in case of multiple
-   * occurrences of the same word in the same sentence.
+   * mathematical signs and numbers in case of expressions such as {@code i<0} (only "i" is stored).
+   * Each word retained (as a String key) is mapped with a list of integers that stores the
+   * occurrences which are tagged as code in the original text. For example: "{@code a} is negative
+   * and is a real number. {@code a} cannot be null" will be stored as a-> [0, 2] since the first
+   * and third occurrences are tagged as code, but not the second one.
    */
   private final Map<String, List<Integer>> wordsMarkedAsCode;
 
@@ -90,7 +89,7 @@ public final class Comment {
    * @param codePattern regular expression used to identify the words marked as code
    */
   private void identifyCodeWords(String codePattern) {
-    String[] subSentences = text.split("\\.");
+    String[] subSentences = text.split("\\. ");
     for (String subSentence : subSentences) {
       Matcher codeMatcher = Pattern.compile(codePattern).matcher(subSentence);
 
@@ -167,14 +166,11 @@ public final class Comment {
 
     Comment comment = (Comment) o;
 
-    if (!text.equals(comment.text)) return false;
-    return wordsMarkedAsCode.equals(comment.wordsMarkedAsCode);
+    return text.equals(comment.text) && wordsMarkedAsCode.equals(comment.wordsMarkedAsCode);
   }
 
   @Override
   public int hashCode() {
-    int result = text.hashCode();
-    result = 31 * result + wordsMarkedAsCode.hashCode();
-    return result;
+    return Objects.hash(text, wordsMarkedAsCode);
   }
 }

--- a/src/main/java/org/toradocu/translator/BasicTranslator.java
+++ b/src/main/java/org/toradocu/translator/BasicTranslator.java
@@ -1,7 +1,5 @@
 package org.toradocu.translator;
 
-import static java.util.stream.Collectors.toList;
-
 import java.util.*;
 import org.toradocu.extractor.BlockTag;
 import org.toradocu.extractor.DocumentedExecutable;
@@ -161,8 +159,8 @@ public class BasicTranslator {
             matchingCodeElements
                 .stream()
                 .filter(c -> matchingSubjects.get(0).getClass().equals(c.getClass()))
-                .collect(toList())
-                .get(0);
+                .findFirst()
+                .orElse(null);
 
         result = translations.get(match);
       }

--- a/src/main/java/org/toradocu/translator/BasicTranslator.java
+++ b/src/main/java/org/toradocu/translator/BasicTranslator.java
@@ -5,7 +5,6 @@ import static java.util.stream.Collectors.toList;
 import java.util.*;
 import org.toradocu.extractor.BlockTag;
 import org.toradocu.extractor.DocumentedExecutable;
-import org.toradocu.extractor.ThrowsTag;
 
 /**
  * The {@code BasicTranslator} class holds the {@code translate()} methods for {@code BlockTag} of
@@ -151,42 +150,20 @@ public class BasicTranslator {
           }
         }
       } else { // Only one of the matching subjects should be used.
-        CodeElement<?> match = null;
 
         // Sort matching subjects according to their priorities (defined in CodeElement#compareTo).
         List<CodeElement<?>> matchingSubjects = new ArrayList<>();
         matchingSubjects.addAll(translations.keySet());
         matchingSubjects.sort(Collections.reverseOrder());
-        // Get all the matching subjects with the same priority (i.e., of the same type).
-        final List<CodeElement<?>> samePriorityElements =
+        // Get all the matching subjects with the same priority (i.e., of the same type)
+        // and pick the first one
+        CodeElement<?> match =
             matchingCodeElements
                 .stream()
                 .filter(c -> matchingSubjects.get(0).getClass().equals(c.getClass()))
-                .collect(toList());
-        // Get the first matching subject tagged with {@code} or the first at all.
-        for (CodeElement<?> matchingSubject : samePriorityElements) {
-          // If the indecision is between two subject matches that are absolutely equal
-          // candidates, then the priority goes to the one which is also a {@code} tag in the
-          // method's Javadoc: isTaggedAsCode checks this property.
-          boolean isTaggedAsCode = false;
-          for (ThrowsTag throwTag : method.throwsTags()) {
-            isTaggedAsCode =
-                !throwTag
-                    .getComment()
-                    .getWordsMarkedAsCode()
-                    .stream()
-                    .filter(matchingSubject.getIdentifiers()::contains)
-                    .collect(toList())
-                    .isEmpty();
-          }
-          if (isTaggedAsCode) {
-            match = matchingSubject;
-            break;
-          }
-        }
-        if (match == null) {
-          match = samePriorityElements.get(0);
-        }
+                .collect(toList())
+                .get(0);
+
         result = translations.get(match);
       }
 

--- a/src/main/java/org/toradocu/translator/JavaElementsCollector.java
+++ b/src/main/java/org/toradocu/translator/JavaElementsCollector.java
@@ -171,7 +171,9 @@ public class JavaElementsCollector {
                 .map(PropositionSeries::getSemanticGraph)
                 .collect(toList());
         for (SemanticGraph sg : sgs) {
-          ids.add(sg.getFirstRoot().word());
+          if (sg.getFirstRoot() != null) {
+            ids.add(sg.getFirstRoot().word());
+          }
         }
       }
     }

--- a/src/main/java/org/toradocu/translator/JavaElementsCollector.java
+++ b/src/main/java/org/toradocu/translator/JavaElementsCollector.java
@@ -171,9 +171,7 @@ public class JavaElementsCollector {
                 .map(PropositionSeries::getSemanticGraph)
                 .collect(toList());
         for (SemanticGraph sg : sgs) {
-          if (sg.getFirstRoot() != null) {
-            ids.add(sg.getFirstRoot().word());
-          }
+          ids.add(sg.getFirstRoot().word());
         }
       }
     }

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -85,7 +85,7 @@ class Matcher {
   private Set<CodeElement<?>> filterMatchingCodeElements(
       String filter, Set<CodeElement<?>> codeElements) {
     Set<CodeElement<?>> minCodeElements = new LinkedHashSet<>();
-    //Handle limit case: filter is a one-letter word.
+    // If the word to match is a one-letter word (or empty string), we look for an exact match.
     int minDistance = 0;
     // Only consider elements with a minimum distance <= the threshold distance.
     if (filter.length() > 1) {

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -85,8 +85,12 @@ class Matcher {
   private Set<CodeElement<?>> filterMatchingCodeElements(
       String filter, Set<CodeElement<?>> codeElements) {
     Set<CodeElement<?>> minCodeElements = new LinkedHashSet<>();
+    //Handle limit case: filter is a one-letter word.
+    int minDistance = 0;
     // Only consider elements with a minimum distance <= the threshold distance.
-    int minDistance = editDistanceThreshold;
+    if (filter.length() > 1) {
+      minDistance = editDistanceThreshold;
+    }
     // Returns the CodeElement(s) with the smallest distance.
     for (CodeElement<?> codeElement : codeElements) {
       int distance = codeElement.getEditDistanceFrom(filter);

--- a/src/main/java/org/toradocu/translator/POSTagger.java
+++ b/src/main/java/org/toradocu/translator/POSTagger.java
@@ -3,7 +3,10 @@ package org.toradocu.translator;
 import edu.stanford.nlp.ling.HasWord;
 import edu.stanford.nlp.ling.TaggedWord;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.toradocu.extractor.Comment;
 
 public class POSTagger {
 
@@ -14,25 +17,75 @@ public class POSTagger {
    * Stanford Parser will take in input a partially tagged sentence, and will adapt its tagging to
    * our previous one.
    *
-   * @param sentence the original sentence to tag, i.e. the comment
-   * @param codeElements list of the words in the sentence that are code elements
+   * @param comment original {@code Comment}
+   * @param placeholderSentence String holding the sentence to tag, with placeholders
+   * @param inequalities List of inequalities corresponding to placeholders
+   * @param sentence original sentence to tag, i.e. the comment
+   * @param parameters method's parameters names
    * @return the partially tagged sentence
    */
-  public static List<TaggedWord> tagWords(List<HasWord> sentence, List<String> codeElements) {
+  static List<TaggedWord> tagWords(
+      Comment comment,
+      String placeholderSentence,
+      List<String> inequalities,
+      List<HasWord> sentence,
+      List<String> parameters) {
+    int inequalityIndex = 0;
+    Map<String, List<Integer>> codeWordsInComment = comment.getWordsMarkedAsCode();
+    Map<String, Integer> codeWordsSeen = new HashMap<>();
+    for (String key : codeWordsInComment.keySet()) {
+      codeWordsSeen.put(key, 0);
+    }
+
     List<TaggedWord> taggedSentence = new ArrayList<>(sentence.size());
     for (HasWord word : sentence) {
       String wordString = word.toString();
       TaggedWord taggedWord = new TaggedWord(wordString);
-      if ((wordString.contains("INEQUALITY")
-              || wordString.equals("null")
-              || wordString.equals("nonnull")
-              || wordString.equals("non-null"))
-          && taggedWord.tag() == null) taggedSentence.add(new TaggedWord(wordString, "JJ"));
-      else if (codeElements.contains(wordString) && taggedWord.tag() == null)
+      if (wordString.contains("INEQUALITY") && taggedWord.tag() == null) {
+        String[] inequalityToken = inequalities.get(inequalityIndex).split(" ");
+        for (String inequalityWord : inequalityToken) {
+          if (codeWordsInComment.get(inequalityWord) != null) {
+            //Behind this placeholder there is a codeword: update counter
+            //of occurrences already seen
+            inequalityWord = inequalityWord;
+            int codeWorCount = codeWordsSeen.get(inequalityWord);
+            List<Integer> occurrenceInComment = codeWordsInComment.get(inequalityWord);
+            for (int occurrence : occurrenceInComment) {
+              if (codeWordsSeen.get(inequalityWord) == occurrence) {
+                codeWordsSeen.put(inequalityWord, ++codeWorCount);
+                break;
+              }
+            }
+          }
+        }
+        inequalityIndex++;
+        taggedSentence.add(new TaggedWord(wordString, "JJ"));
+      } else if (wordString.equals("null")
+          || wordString.equals("nonnull")
+          || wordString.equals("non-null") && taggedWord.tag() == null) {
+        taggedSentence.add(new TaggedWord(wordString, "JJ"));
+      } else if (codeWordsInComment.get(wordString) != null) {
+        // this wordString is present in the map of word tagged as code.
+        // Is it the right one? Check its occurrence.
+        List<Integer> occurrenceInComment = codeWordsInComment.get(wordString);
+        int codeWorCount = codeWordsSeen.get(wordString);
+        for (int occurrence : occurrenceInComment) {
+          if (codeWordsSeen.get(wordString) == occurrence) {
+            //This occurrence of the word is a codeword: tag it as NN
+            taggedSentence.add(new TaggedWord(wordString, "NN"));
+          } else {
+            //This is not the right occurrence: update counter but add no tag
+            codeWordsSeen.put(wordString, ++codeWorCount);
+            taggedSentence.add(taggedWord);
+          }
+        }
+      } else if (parameters != null && parameters.contains(wordString)) {
+        //Last attempt: no code tags found. Make an assumption over parameters names.
         taggedSentence.add(new TaggedWord(wordString, "NN"));
-      else taggedSentence.add(taggedWord);
+      } else {
+        taggedSentence.add(taggedWord);
+      }
     }
-
     return taggedSentence;
   }
 }

--- a/src/main/java/org/toradocu/translator/Parser.java
+++ b/src/main/java/org/toradocu/translator/Parser.java
@@ -281,14 +281,14 @@ class MethodComment {
 
     MethodComment that = (MethodComment) o;
 
-    if (!comment.equals(that.comment)) return false;
-    return method.equals(that.method);
+    if (comment != null ? !comment.equals(that.comment) : that.comment != null) return false;
+    return method != null ? method.equals(that.method) : that.method == null;
   }
 
   @Override
   public int hashCode() {
-    int result = comment.hashCode();
-    result = 31 * result + method.hashCode();
+    int result = comment != null ? comment.hashCode() : 0;
+    result = 31 * result + (method != null ? method.hashCode() : 0);
     return result;
   }
 }

--- a/src/main/java/org/toradocu/translator/preprocess/ImplicitParamSubjectPatterns.java
+++ b/src/main/java/org/toradocu/translator/preprocess/ImplicitParamSubjectPatterns.java
@@ -21,45 +21,56 @@ public class ImplicitParamSubjectPatterns implements PreprocessingPhase {
   public String run(BlockTag tag, DocumentedExecutable excMember) {
     String comment = tag.getComment().getText();
     String parameterName = ((ParamTag) tag).getParameter().getName();
-    String[] patterns = {
-      "must be",
+    String[] positivePatterns = {"must be", "will be", "Will be", "Must be"};
+
+    String[] negativePatterns = {
       "must not be",
-      "must never",
-      "will be",
+      "must not return",
+      "must never be",
+      "must never return",
       "will not be",
       "will never be",
       "can't be",
       "cannot be",
-      "should be",
       "should not be",
       "shouldn't be",
       "may not be",
-      "Must be",
       "Must not be",
       "must'nt be",
-      "Will be",
       "Will not be",
       "Can't be",
       "Cannot be",
-      "Should be",
       "Should not be",
       "Shouldn't be",
       "May not be"
     };
-    Matcher matcher = Pattern.compile("\\(.*").matcher(comment);
-    String separator = matcher.find() ? " " : ".";
+
     boolean noReplacedYet = true; //Tells if there was already a replacement in the phrase
-    for (String pattern : patterns) {
+    for (String pattern : positivePatterns) {
+      String stringToReplace = pattern;
+      if (comment.contains(". It " + pattern)) {
+        stringToReplace = ". It " + pattern;
+      }
       if (comment.contains(pattern)) {
-        String replacement = separator + parameterName + " " + pattern;
-        comment = comment.replace(pattern, replacement);
+        String replacement = ". {@code " + parameterName + "} " + " is ";
+        comment = comment.replace(stringToReplace, replacement);
+        noReplacedYet = false;
+      }
+    }
+    for (String pattern : negativePatterns) {
+      String stringToReplace = pattern;
+      if (comment.contains(". It " + pattern)) {
+        stringToReplace = ". It " + pattern;
+      }
+      if (comment.contains(pattern)) {
+        String replacement = ". {@code " + parameterName + "} " + " is not ";
+        comment = comment.replace(stringToReplace, replacement);
         noReplacedYet = false;
       }
     }
 
     //manage description following a comma
     if (noReplacedYet) {
-      //TODO make this a preprocessing phase
       comment = comment.replace(";", ",");
       String[] beginnings = {"the", "a", "an", "any"};
       String commaPattern = ".*(, (?!default)(?!may be)(?!can be)(?!could be)(?!possibly))(.*)";
@@ -79,7 +90,7 @@ public class ImplicitParamSubjectPatterns implements PreprocessingPhase {
               break;
             }
           }
-          comment = tokens[0] + ". " + parameterName + " is " + tokens[1];
+          comment = tokens[0] + ". {@code " + parameterName + "} is " + tokens[1];
           noReplacedYet = false;
         }
       }
@@ -107,7 +118,7 @@ public class ImplicitParamSubjectPatterns implements PreprocessingPhase {
                 //delete article
                 comment = comment.replaceFirst(tokens[0], "");
 
-              String firstPart = parameterName + " is " + mayBeAdj + ". ";
+              String firstPart = "{@code " + parameterName + "} is " + mayBeAdj + ". ";
               comment = firstPart + comment;
               break;
             }

--- a/src/main/java/org/toradocu/translator/preprocess/ImplicitParamSubjectPatterns.java
+++ b/src/main/java/org/toradocu/translator/preprocess/ImplicitParamSubjectPatterns.java
@@ -21,28 +21,33 @@ public class ImplicitParamSubjectPatterns implements PreprocessingPhase {
   public String run(BlockTag tag, DocumentedExecutable excMember) {
     String comment = tag.getComment().getText();
     String parameterName = ((ParamTag) tag).getParameter().getName();
-    String[] positivePatterns = {"must be", "will be", "Will be", "Must be"};
+    String[] positivePatterns = {"must be", "Must be", "will be", "Will be"};
 
     String[] negativePatterns = {
       "must not be",
-      "must not return",
-      "must never be",
-      "must never return",
-      "will not be",
-      "will never be",
-      "can't be",
-      "cannot be",
-      "should not be",
-      "shouldn't be",
-      "may not be",
       "Must not be",
-      "must'nt be",
+      "must not return",
+      "Must not return",
+      "must never be",
+      "Must never be",
+      "must never return",
+      "Must never return",
+      "will not be",
       "Will not be",
+      "will never be",
+      "Will never be",
+      "can't be",
       "Can't be",
+      "cannot be",
       "Cannot be",
+      "should not be",
       "Should not be",
+      "shouldn't be",
       "Shouldn't be",
-      "May not be"
+      "may not be",
+      "May not be",
+      "must'nt be",
+      "Must'nt be"
     };
 
     boolean noReplacedYet = true; //Tells if there was already a replacement in the phrase

--- a/src/main/java/org/toradocu/translator/preprocess/Preprocessor.java
+++ b/src/main/java/org/toradocu/translator/preprocess/Preprocessor.java
@@ -15,7 +15,8 @@ public class Preprocessor {
 
   public BlockTag preprocess(BlockTag tag, DocumentedExecutable excMember) {
     for (PreprocessingPhase phase : phases) {
-      tag.setComment(new Comment(phase.run(tag, excMember)));
+      String preprocessedText = phase.run(tag, excMember);
+      tag.setComment(new Comment(preprocessedText, tag.getComment().getWordsMarkedAsCode()));
     }
     return tag;
   }

--- a/src/test/java/org/toradocu/accuracy/PrecisionRecallCommonsMath3.java
+++ b/src/test/java/org/toradocu/accuracy/PrecisionRecallCommonsMath3.java
@@ -22,7 +22,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testUnivariateSolverUtils() throws Exception {
-    test("org.apache.commons.math3.analysis.solvers.UnivariateSolverUtils", 1, 1, 1, 0, 0, 1);
+    test("org.apache.commons.math3.analysis.solvers.UnivariateSolverUtils", 1, 1, 1, 1, 0, 1);
   }
 
   @Test
@@ -37,7 +37,7 @@ public class PrecisionRecallCommonsMath3 extends AbstractPrecisionRecallTestSuit
 
   @Test
   public void testAdaptiveStepsizeIntegrator() throws Exception {
-    test("org.apache.commons.math3.ode.nonstiff.AdaptiveStepsizeIntegrator", 1, 1, 1, 0.8, 1, 1);
+    test("org.apache.commons.math3.ode.nonstiff.AdaptiveStepsizeIntegrator", 1, 1, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/accuracy/PrecisionRecallFreeCol.java
+++ b/src/test/java/org/toradocu/accuracy/PrecisionRecallFreeCol.java
@@ -25,6 +25,6 @@ public class PrecisionRecallFreeCol extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testUnit() throws Exception {
-    test("net.sf.freecol.common.model.Unit", 1, 1, 0, 1, 0.0769, 0.125);
+    test("net.sf.freecol.common.model.Unit", 1, 1, 0, 1, 0.083, 0.125);
   }
 }

--- a/src/test/java/org/toradocu/accuracy/PrecisionRecallGuava19.java
+++ b/src/test/java/org/toradocu/accuracy/PrecisionRecallGuava19.java
@@ -40,7 +40,7 @@ public class PrecisionRecallGuava19 extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testCacheLoader() throws Exception {
-    test("com.google.common.cache.CacheLoader", 1, 1, 1, 0.6, 1, 1);
+    test("com.google.common.cache.CacheLoader", 1, 1, 1, 1, 1, 1);
   }
 
   @Test
@@ -60,7 +60,7 @@ public class PrecisionRecallGuava19 extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testConcurrentHashMultiset() throws Exception {
-    test("com.google.common.collect.ConcurrentHashMultiset", 1, 1, 0.5, 1, 1, 1);
+    test("com.google.common.collect.ConcurrentHashMultiset", 1, 1, 1, 1, 1, 1);
   }
 
   @Test
@@ -80,7 +80,7 @@ public class PrecisionRecallGuava19 extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testShorts() throws Exception {
-    test("com.google.common.primitives.Shorts", 0.6, 0.5, 1, 1, 1, 1);
+    test("com.google.common.primitives.Shorts", 0.75, 0.5, 1, 1, 1, 1);
   }
 
   @Test

--- a/src/test/java/org/toradocu/accuracy/PrecisionRecallPlumeLib.java
+++ b/src/test/java/org/toradocu/accuracy/PrecisionRecallPlumeLib.java
@@ -30,7 +30,7 @@ public class PrecisionRecallPlumeLib extends AbstractPrecisionRecallTestSuite {
 
   @Test
   public void testWeakIdentityHashMap() throws Exception {
-    test("plume.WeakIdentityHashMap", 1, 1, 1, 1, 1, 1);
+    test("plume.WeakIdentityHashMap", 1, 1, 1, 1, 0, 0);
   }
 
   @Test

--- a/src/test/java/org/toradocu/extractor/CommentTest.java
+++ b/src/test/java/org/toradocu/extractor/CommentTest.java
@@ -1,9 +1,10 @@
 package org.toradocu.extractor;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.nullValue;
 import static org.junit.Assert.assertThat;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.junit.Test;
 
@@ -11,29 +12,47 @@ public class CommentTest {
 
   @Test
   public void testComment() {
-    String doubleTagged = "This comment contains a {@code codeElement} and another {@code one}";
-    String tagged = "This comment contains a {@code codeElement}";
-    String complexTagged = "This comment contains a {@code complex codeElement}";
+    String multipleTags =
+        "This comment contains a {@code codeElement}, another {@code one}, and a last {@code codeElement}";
+    String simpleTag = "This comment contains a {@code codeElement}";
+    String complexTag = "This comment contains a {@code complex codeElement}";
+    String expressionTag = "This comment contains an expression: {@code i<0}";
 
-    Comment commentObject = new Comment(tagged);
-    assertThat(commentObject.getWordsMarkedAsCode().contains("codeElement"), is(true));
-    assertThat(commentObject.getText().equals("This comment contains a codeElement"), is(true));
+    Comment simpleComment = new Comment(simpleTag);
+    List<Integer> codeWordOccurrences = simpleComment.getWordsMarkedAsCode().get("codeElement");
+    assertThat(codeWordOccurrences, not(is(nullValue())));
+    assertThat(codeWordOccurrences.size(), is(1));
+    assertThat(codeWordOccurrences.get(0), is(0));
 
-    commentObject = new Comment(doubleTagged);
-    List<String> codeWords = new ArrayList<String>();
-    codeWords.add("codeElement");
-    codeWords.add("one");
-    assertThat(commentObject.getWordsMarkedAsCode().equals(codeWords), is(true));
-    assertThat(
-        commentObject.getText().equals("This comment contains a codeElement and another one"),
-        is(true));
+    Comment multiTagComment = new Comment(multipleTags);
+    codeWordOccurrences = multiTagComment.getWordsMarkedAsCode().get("codeElement");
+    //codeElement is tagged as code twice (both the first and second occurrence) in multiTagComment.
+    //Thus we expect to find the values 0 and 1 (first and second occurrence).
+    assertThat(codeWordOccurrences, not(is(nullValue())));
+    assertThat(codeWordOccurrences.size(), is(2));
+    assertThat(codeWordOccurrences.get(0), is(0));
+    assertThat(codeWordOccurrences.get(1), is(1));
 
-    codeWords.clear();
-    codeWords.add("complex");
-    codeWords.add("codeElement");
-    commentObject = new Comment(complexTagged);
-    assertThat(commentObject.getWordsMarkedAsCode().equals(codeWords), is(true));
-    assertThat(
-        commentObject.getText().equals("This comment contains a complex codeElement"), is(true));
+    codeWordOccurrences = multiTagComment.getWordsMarkedAsCode().get("one");
+    assertThat(codeWordOccurrences, not(is(nullValue())));
+    assertThat(codeWordOccurrences.size(), is(1));
+    assertThat(codeWordOccurrences.get(0), is(0));
+
+    Comment complexComment = new Comment(complexTag);
+    codeWordOccurrences = complexComment.getWordsMarkedAsCode().get("complex");
+    assertThat(codeWordOccurrences, not(is(nullValue())));
+    assertThat(codeWordOccurrences.size(), is(1));
+    assertThat(codeWordOccurrences.get(0), is(0));
+
+    codeWordOccurrences = complexComment.getWordsMarkedAsCode().get("codeElement");
+    assertThat(codeWordOccurrences, not(is(nullValue())));
+    assertThat(codeWordOccurrences.size(), is(1));
+    assertThat(codeWordOccurrences.get(0), is(0));
+
+    //From expression such as i<0, we do not retain signs and numbers
+    Comment exprComment = new Comment(expressionTag);
+    assertThat(exprComment.getWordsMarkedAsCode().size(), is(1));
+    codeWordOccurrences = exprComment.getWordsMarkedAsCode().get("i");
+    assertThat(codeWordOccurrences, not(is(nullValue())));
   }
 }

--- a/src/test/java/org/toradocu/translator/PropositionSeriesTest.java
+++ b/src/test/java/org/toradocu/translator/PropositionSeriesTest.java
@@ -222,10 +222,10 @@ public class PropositionSeriesTest {
   public void testIssue97() {
     // https://github.com/albertogoffi/toradocu/issues/97
     PropositionSeries propositions =
-        getPropositions(new Comment("shape is INEQUALITY_0 or scale is INEQUALITY_1."), null);
+        getPropositions(new Comment("shape is <= 0 or scale is <= 0."), null);
     assertThat(propositions.numberOfPropositions(), is(2));
-    assertThat(propositions.getPropositions().get(0).toString(), is("(shape, is INEQUALITY_0)"));
-    assertThat(propositions.getPropositions().get(1).toString(), is("(scale, is INEQUALITY_1)"));
+    assertThat(propositions.getPropositions().get(0).toString(), is("(shape, is <= 0)"));
+    assertThat(propositions.getPropositions().get(1).toString(), is("(scale, is <= 0)"));
     assertThat(propositions.getConjunctions().size(), is(1));
     assertThat(propositions.getConjunctions().get(0), is(Conjunction.OR));
   }

--- a/src/test/resources/goal-output/plume-lib-1.1.0/plume.WeakIdentityHashMap_goal.json
+++ b/src/test/resources/goal-output/plume-lib-1.1.0/plume.WeakIdentityHashMap_goal.json
@@ -362,7 +362,7 @@
     "returnTag": {
       "comment": "the value to which this map maps the specified key, or null if the map contains no mapping for this key.",
       "kind": "RETURN",
-      "condition": ""
+      "condition": "target.containsKey(args[0])?result==null"
     },
     "throwsTags": []
   },

--- a/src/test/resources/goal-output/plume-lib-1.1.0/plume.WeakIdentityHashMap_goal.json
+++ b/src/test/resources/goal-output/plume-lib-1.1.0/plume.WeakIdentityHashMap_goal.json
@@ -362,7 +362,7 @@
     "returnTag": {
       "comment": "the value to which this map maps the specified key, or null if the map contains no mapping for this key.",
       "kind": "RETURN",
-      "condition": "target.containsKey(args[0])?result==null"
+      "condition": "target.containsKey(args[0])==false ? result==null"
     },
     "throwsTags": []
   },


### PR DESCRIPTION
The new data structure is a `Map` that stores each word tagged as `@code` along with the list of occurrences that were actually tagged in the sentence. Thus, if there are multiple occurrences of that word in the comment, the `Map` knows which one among the first, the second, etc. occurrence was tagged.
The better management of inline code tags also led to slightly better results in accuracy.