### PR TITLE
Address TODOs in JavadocExtractor#createParamTag

### DIFF
--- a/src/main/java/org/toradocu/extractor/JavadocExtractor.java
+++ b/src/main/java/org/toradocu/extractor/JavadocExtractor.java
@@ -305,8 +305,19 @@ public final class JavadocExtractor {
 
     final List<DocumentedParameter> matchingParams =
         parameters.stream().filter(p -> p.getName().equals(paramName)).collect(toList());
+
+    if (matchingParams.isEmpty()) {
+      log.warn("No matching parameter found for name " + paramName + ". Is the Javadoc correct?");
+      return null;
+    }
+    if (matchingParams.size() > 1) {
+      log.warn("More than one parameter matches name " + paramName + ". Is the Javadoc correct?");
+      return null;
+    }
     // TODO If paramName not present in paramNames => issue a warning about incorrect documentation!
     // TODO If more than one matching parameter found => issue a warning about incorrect documentation!
+    // TODO Or should we throw an exception? If we return null, no paramTag will be created. What would
+    // TODO be the consequences on the final specification?
     Comment commentObject = new Comment(blockTag.getContent().toText());
     return new ParamTag(matchingParams.get(0), commentObject);
   }


### PR DESCRIPTION
The TODOs suggested to issue a warning in case there is no matching parameter or there are more than one for the param name in the Javadoc. This is what the pull request implements.

However, I wonder if it would be better to throw an exception. If we don't, we have to return null and the final generated specification would be incomplete. Throwing an exception, Toradocu would not produce the specification at all.