### PR TITLE
Issue a precise error for annotation declaration

### DIFF
--- a/src/main/java/org/toradocu/extractor/JavadocExtractor.java
+++ b/src/main/java/org/toradocu/extractor/JavadocExtractor.java
@@ -428,6 +428,17 @@ public final class JavadocExtractor {
       definitionOpt = cu.getEnumByName(typeName);
     }
 
+    if (!definitionOpt.isPresent()) {
+      Optional<AnnotationDeclaration> annotationOpt = cu.getAnnotationDeclarationByName(typeName);
+      if (annotationOpt.isPresent()) {
+        throw new IllegalArgumentException(
+            "Unsupported declaration: "
+                + typeName
+                + " in "
+                + sourcePath
+                + " is an annotation declaration, not a class or interface");
+      }
+    }
     if (definitionOpt.isPresent()) {
       if (!nestedClassName.isEmpty()) {
         // Nested class.

--- a/src/main/java/org/toradocu/extractor/JavadocExtractor.java
+++ b/src/main/java/org/toradocu/extractor/JavadocExtractor.java
@@ -427,18 +427,6 @@ public final class JavadocExtractor {
     if (!definitionOpt.isPresent()) {
       definitionOpt = cu.getEnumByName(typeName);
     }
-
-    if (!definitionOpt.isPresent()) {
-      Optional<AnnotationDeclaration> annotationOpt = cu.getAnnotationDeclarationByName(typeName);
-      if (annotationOpt.isPresent()) {
-        throw new IllegalArgumentException(
-            "Unsupported declaration: "
-                + typeName
-                + " in "
-                + sourcePath
-                + " is an annotation declaration, not a class or interface");
-      }
-    }
     if (definitionOpt.isPresent()) {
       if (!nestedClassName.isEmpty()) {
         // Nested class.
@@ -455,6 +443,16 @@ public final class JavadocExtractor {
       } else {
         // Top-level class, enum, or interface.
         return definitionOpt.get();
+      }
+    } else {
+      Optional<AnnotationDeclaration> annotationOpt = cu.getAnnotationDeclarationByName(typeName);
+      if (annotationOpt.isPresent()) {
+        throw new IllegalArgumentException(
+            "Unsupported declaration: "
+                + typeName
+                + " in "
+                + sourcePath
+                + " is an annotation declaration, not a class or interface");
       }
     }
 


### PR DESCRIPTION
A .java source file could contain an annotation declaration such as `@interface` instead of an actual class or interface. 
Since Toradocu does not support this kind of declaration and accepts any .java file, I think a more precise error would be better than the generic `"Impossible to find a class or interface" `issued in all the other cases.