### PR TITLE
Manage regex meta-characters when looking for code words

### DIFF
--- a/src/main/java/org/toradocu/extractor/Comment.java
+++ b/src/main/java/org/toradocu/extractor/Comment.java
@@ -142,7 +142,21 @@ public final class Comment {
    * @return the computed occurrence
    */
   private int countStringOccurrence(String word, String subSentence, int limitIndex) {
-    Matcher matcher = Pattern.compile("\\b" + word + "\\b").matcher(subSentence);
+    if (word.matches(".*[\\[\\]\\(\\)].*")) {
+      // Escape special characters to prevent errors in subsequent pattern compiling
+      word =
+          word.replaceAll("\\]", "\\\\]")
+              .replaceAll("\\[", "\\\\[")
+              .replaceAll("\\)", "\\)")
+              .replaceAll("\\(", "\\\\(")
+              .replaceAll("\\.", "\\\\.");
+
+      // Word boundaries do not work in case of special characters, thus use look ahead and look behind
+      word = "(?<!" + word + ")" + word + "(?!" + word + ")";
+    } else {
+      word = "\\b" + word + "\\b";
+    }
+    Matcher matcher = Pattern.compile(word).matcher(subSentence);
     int i = 0;
     while (matcher.find() && matcher.start() < limitIndex) {
       //Looping on method find preserves the order of matches,

--- a/src/test/java/org/toradocu/extractor/CommentTest.java
+++ b/src/test/java/org/toradocu/extractor/CommentTest.java
@@ -16,6 +16,7 @@ public class CommentTest {
         "This comment contains a {@code codeElement}, another {@code one}, and a last {@code codeElement}";
     String simpleTag = "This comment contains a {@code codeElement}";
     String complexTag = "This comment contains a {@code complex codeElement}";
+    String specialCharTag = "This comment contains {@code specialCharacters[]}";
     String expressionTag = "This comment contains an expression: {@code i<0}";
     String regularHTMLTags = "This comment contains <b>bold text</b>";
     String selfClosingHTMLTags = "This comment contains a break <br/>";
@@ -48,6 +49,12 @@ public class CommentTest {
     assertThat(codeWordOccurrences.get(0), is(0));
 
     codeWordOccurrences = complexComment.getWordsMarkedAsCode().get("codeElement");
+    assertThat(codeWordOccurrences, not(is(nullValue())));
+    assertThat(codeWordOccurrences.size(), is(1));
+    assertThat(codeWordOccurrences.get(0), is(0));
+
+    Comment specialCharComment = new Comment(specialCharTag);
+    codeWordOccurrences = specialCharComment.getWordsMarkedAsCode().get("specialCharacters[]");
     assertThat(codeWordOccurrences, not(is(nullValue())));
     assertThat(codeWordOccurrences.size(), is(1));
     assertThat(codeWordOccurrences.get(0), is(0));


### PR DESCRIPTION
Toradocu was not handling correctly regex meta-characters when performing pattern matching to keep track of code words inside comments (leading to `java.util.regex.PatternSyntaxException`).  This pull request manages such special expressions as common ones.