### PR TITLE
Adjust receiver name if conflicting for Randoop

### DIFF
--- a/src/main/java/org/toradocu/conf/Configuration.java
+++ b/src/main/java/org/toradocu/conf/Configuration.java
@@ -162,7 +162,7 @@ public enum Configuration {
     converter = FileConverter.class,
     hidden = true
   )
-  private File randoopSpecs;
+  private static File randoopSpecs;
 
   @Parameter(
     names = "--disable-semantics",
@@ -481,7 +481,7 @@ public enum Configuration {
    *
    * @return the file where to export Toradocu generated specifications as Randoop specifications
    */
-  public File randoopSpecsFile() {
+  public static File randoopSpecsFile() {
     return randoopSpecs;
   }
 

--- a/src/main/java/org/toradocu/translator/CommentTranslator.java
+++ b/src/main/java/org/toradocu/translator/CommentTranslator.java
@@ -83,8 +83,8 @@ public class CommentTranslator {
       Operation operation = Operation.getOperation(member.getExecutable());
       List<String> paramNames =
           member.getParameters().stream().map(DocumentedParameter::getName).collect(toList());
-      Identifiers identifiers =
-          new Identifiers(paramNames, Configuration.RECEIVER, Configuration.RETURN_VALUE);
+      String receiverID = adjustReceiverName(Configuration.RECEIVER, paramNames);
+      Identifiers identifiers = new Identifiers(paramNames, receiverID, Configuration.RETURN_VALUE);
       OperationSpecification spec = new OperationSpecification(operation, identifiers);
 
       List<PreSpecification> preSpecifications = new ArrayList<>();
@@ -109,6 +109,21 @@ public class CommentTranslator {
       specs.put(member, spec);
     }
     return specs;
+  }
+
+  /**
+   * If randoop sepcs are enabled and receiver name conflicts with one parameter name, adjust the
+   * receiver name.
+   *
+   * @param receiver original receiver name
+   * @param paramNames list of parameters names
+   * @return adjusted receiver name
+   */
+  private static String adjustReceiverName(String receiver, List<String> paramNames) {
+    if (paramNames.contains(receiver) && Configuration.randoopSpecsFile() != null) {
+      return receiver + "-class-ID";
+    }
+    return receiver;
   }
 
   /**


### PR DESCRIPTION
This fix avoids duplicated identifier that generate conflicts in Randoop