### PR TITLE
Checks to prevent null dereference

### DIFF
--- a/src/main/java/org/toradocu/translator/BasicTranslator.java
+++ b/src/main/java/org/toradocu/translator/BasicTranslator.java
@@ -58,7 +58,11 @@ public class BasicTranslator {
       Iterator<String> it = conditions.iterator();
       StringBuilder conditionsBuilder = new StringBuilder("(" + it.next() + ")");
       while (it.hasNext()) {
-        conditionsBuilder.append(Conjunction.OR + "(" + it.next() + ")");
+        //prevent redundancy
+        String nextCondition = it.next().replaceAll(" ", "");
+        if (!conditionsBuilder.toString().contains(nextCondition)) {
+          conditionsBuilder.append(Conjunction.OR + "(" + nextCondition + ")");
+        }
       }
       return conditionsBuilder.toString();
     }

--- a/src/main/java/org/toradocu/translator/Matcher.java
+++ b/src/main/java/org/toradocu/translator/Matcher.java
@@ -347,7 +347,10 @@ class Matcher {
           pcount++;
         }
       }
-      if (foundArgMatch) break;
+      if (foundArgMatch) {
+        firstMatch = currentMatch;
+        break;
+      }
     }
     if (foundArgMatch && paramForMatch.size() == args.length) {
       String exp = firstMatch.getJavaExpression();
@@ -396,6 +399,13 @@ class Matcher {
         match = sortedCodeElements.stream().findFirst().get().getJavaExpression();
       }
     }
+    if (match != null
+        && firstMatch instanceof MethodCodeElement
+        && !((MethodCodeElement) firstMatch).getNullDereferenceCheck().isEmpty()) {
+      match =
+          "(" + ((MethodCodeElement) firstMatch).getNullDereferenceCheck() + ") && (" + match + ")";
+    }
+
     return match;
   }
 

--- a/src/main/java/org/toradocu/translator/MethodCodeElement.java
+++ b/src/main/java/org/toradocu/translator/MethodCodeElement.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;
 import java.util.StringJoiner;
+import org.toradocu.conf.Configuration;
 
 /**
  * This class represents an instance method code element for use in translation. It holds String
@@ -19,6 +20,8 @@ public class MethodCodeElement extends CodeElement<Method> {
   /** The arguments of this method. */
   private String[] args;
 
+  private String nullDereferenceCheck;
+
   /**
    * Constructs and initializes a {@code MethodCodeElement} that identifies the given method. The
    * given method must take no arguments.
@@ -29,7 +32,11 @@ public class MethodCodeElement extends CodeElement<Method> {
   public MethodCodeElement(String receiver, Method method) {
     super(method);
     this.receiver = receiver;
-
+    if (!receiver.equals(Configuration.RECEIVER)) {
+      this.nullDereferenceCheck = "(" + receiver + "==null)==false";
+    } else {
+      this.nullDereferenceCheck = "";
+    }
     // Add name identifier.
     String methodName = method.getName();
     if (methodName.startsWith("get")) {
@@ -66,6 +73,10 @@ public class MethodCodeElement extends CodeElement<Method> {
    */
   public void setParameters(List<String> parameters) {
     this.parameters = parameters.toArray(new String[0]);
+  }
+
+  public String getNullDereferenceCheck() {
+    return nullDereferenceCheck;
   }
 
   @Override

--- a/src/test/java/org/toradocu/translator/NullDereferenceTest.java
+++ b/src/test/java/org/toradocu/translator/NullDereferenceTest.java
@@ -1,0 +1,103 @@
+package org.toradocu.translator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.gson.reflect.TypeToken;
+import java.io.BufferedReader;
+import java.lang.reflect.Type;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.tools.JavaCompiler;
+import javax.tools.ToolProvider;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.toradocu.Toradocu;
+import org.toradocu.output.util.JsonOutput;
+import org.toradocu.util.GsonInstance;
+
+public class NullDereferenceTest {
+  private static final Path resourcesPath = Paths.get("src", "test", "resources");
+  private static final Path expectedOutput =
+      Paths.get("src/test/resources/expected-output/nulldereference.ResourceManager_goal.json");
+  private static final Path actualOutput = Paths.get("nulldereference.ResourceManager_out.json");
+
+  private static Path sourcePath;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    sourcePath = Paths.get(resourcesPath.toString(), "example/nulldereference", "Resource.java");
+
+    JavaCompiler compiler = ToolProvider.getSystemJavaCompiler();
+    int compilerExitCode = compiler.run(null, null, null, sourcePath.toString());
+    assertThat(compilerExitCode, is(0));
+  }
+
+  @Test
+  public void generatedSpecificationTest() throws Exception {
+    String targetPath = sourcePath.getParent().getParent().toString();
+
+    String[] toradocuArgs =
+        new String[] {
+          "--target-class",
+          "nulldereference.ResourceManager",
+          "--condition-translator-output",
+          actualOutput.toString(),
+          "--class-dir",
+          targetPath,
+          "--source-dir",
+          targetPath,
+          "--expected-output",
+          expectedOutput.toString()
+        };
+    List<String> argsList = new ArrayList<>(Arrays.asList(toradocuArgs));
+    Toradocu.main(argsList.toArray(new String[0]));
+    assertTrue(Files.exists(actualOutput));
+
+    Type listType = new TypeToken<List<JsonOutput>>() {}.getType();
+    try (BufferedReader actualOutputReader = Files.newBufferedReader(actualOutput);
+        BufferedReader expectedOutputReader = Files.newBufferedReader(expectedOutput)) {
+      List<JsonOutput> actualSpecs = GsonInstance.gson().fromJson(actualOutputReader, listType);
+      List<JsonOutput> expectedSpecs = GsonInstance.gson().fromJson(expectedOutputReader, listType);
+      assertThat(actualSpecs.size(), is(equalTo(expectedSpecs.size())));
+
+      for (int i = 0; i < actualSpecs.size(); i++) {
+        JsonOutput actualSpec = actualSpecs.get(i);
+        JsonOutput expectedSpec = expectedSpecs.get(i);
+        if (actualSpec.throwsTags != null) {
+          for (int j = 0; j < actualSpec.throwsTags.size(); j++) {
+            assertThat(
+                actualSpec.throwsTags.get(j).getCondition().replaceAll("\\s+", ""),
+                is(
+                    equalTo(
+                        expectedSpec
+                            .throwsTags
+                            .get(j)
+                            .getCondition()
+                            .replaceAll("\\s+", "")
+                            .trim())));
+          }
+        }
+        if (actualSpec.paramTags != null) {
+          for (int j = 0; j < actualSpec.paramTags.size(); j++) {
+            assertThat(
+                actualSpec.paramTags.get(j).getCondition().replaceAll("\\s+", ""),
+                is(equalTo(expectedSpec.paramTags.get(j).getCondition().replaceAll("\\s+", ""))));
+          }
+        }
+        if (actualSpec.returnTag != null)
+          assertThat(
+              actualSpec.returnTag.getCondition().replaceAll("\\s+", ""),
+              is(equalTo(expectedSpec.returnTag.getCondition().replaceAll("\\s+", ""))));
+      }
+    } finally {
+      Files.delete(actualOutput);
+    }
+  }
+}

--- a/src/test/resources/example/nulldereference/Resource.java
+++ b/src/test/resources/example/nulldereference/Resource.java
@@ -1,0 +1,12 @@
+package nulldereference;
+
+public class Resource {
+
+    private boolean empty;
+
+    public boolean isEmpty(){
+        return empty;
+    }
+
+
+}

--- a/src/test/resources/example/nulldereference/ResourceManager.java
+++ b/src/test/resources/example/nulldereference/ResourceManager.java
@@ -1,0 +1,25 @@
+package nulldereference;
+
+public class ResourceManager {
+
+    /**
+     * With this example, the resource should be checked for nullness.
+     *
+     * @param resource the resource to check
+     * @return true if the resource is empty
+     */
+    public boolean simpleNullDeref(Resource resource){
+        return resource.isEmpty();
+    }
+
+    /**
+     * The resource must be checked for nullness first even if the explicit check
+     * is the last condition.
+     *
+     * @param resource the resource to check
+     * @return true if the resource is empty. Resource is not null
+     */
+    public boolean complexNullDeref(Resource resource){
+        return resource.isEmpty();
+    }
+}

--- a/src/test/resources/expected-output/example.AClass_goal.json
+++ b/src/test/resources/expected-output/example.AClass_goal.json
@@ -384,7 +384,7 @@
     "returnTag": {
       "comment": "true if the numbers are equal.",
       "kind": "RETURN",
-      "condition": "args[0].equals(args[1]) ? methodResultID==true : methodResultID==false"
+      "condition": "((args[0]==null)==false)&&(args[0].equals(args[1]))?methodResultID==true:methodResultID==false"
     },
     "throwsTags": []
   },

--- a/src/test/resources/expected-output/example.AClass_goal.json
+++ b/src/test/resources/expected-output/example.AClass_goal.json
@@ -81,7 +81,7 @@
         "codeTags": [],
         "comment": "x is empty.",
         "kind": "THROWS",
-        "condition": "args[0].isEmpty()"
+        "condition": "((args[0]==null)==false)&&(args[0].isEmpty())"
       }
     ]
   },

--- a/src/test/resources/expected-output/nulldereference.ResourceManager_goal.json
+++ b/src/test/resources/expected-output/nulldereference.ResourceManager_goal.json
@@ -1,0 +1,96 @@
+[
+  {
+    "signature": "simpleNullDeref(nulldereference.Resource resource)",
+    "name": "simpleNullDeref",
+    "containingClass": {
+      "qualifiedName": "nulldereference.ResourceManager",
+      "name": "ResourceManager",
+      "isArray": false
+    },
+    "targetClass": "nulldereference.ResourceManager",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "nulldereference.Resource",
+          "name": "Resource",
+          "isArray": false
+        },
+        "name": "resource"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "nulldereference.Resource",
+            "name": "Resource",
+            "isArray": false
+          },
+          "name": "resource"
+        },
+        "comment": "the resource to check.",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "returnTag": {
+      "comment": "true if the resource is empty.",
+      "kind": "RETURN",
+      "condition": "((args[0]==null)==false) && (args[0].isEmpty()) ? methodResultID == true : methodResultID == false"
+    },
+    "throwsTags": []
+  },
+  {
+    "signature": "complexNullDeref(nulldereference.Resource resource)",
+    "name": "complexNullDeref",
+    "containingClass": {
+      "qualifiedName": "nulldereference.ResourceManager",
+      "name": "ResourceManager",
+      "isArray": false
+    },
+    "targetClass": "nulldereference.ResourceManager",
+    "isVarArgs": false,
+    "returnType": {
+      "qualifiedName": "boolean",
+      "name": "boolean",
+      "isArray": false
+    },
+    "parameters": [
+      {
+        "type": {
+          "qualifiedName": "nulldereference.Resource",
+          "name": "Resource",
+          "isArray": false
+        },
+        "name": "resource"
+      }
+    ],
+    "paramTags": [
+      {
+        "parameter": {
+          "type": {
+            "qualifiedName": "nulldereference.Resource",
+            "name": "Resource",
+            "isArray": false
+          },
+          "name": "resource"
+        },
+        "comment": "the resource to check.",
+        "kind": "PARAM",
+        "condition": ""
+      }
+    ],
+    "returnTag": {
+      "comment": "true if the resource is empty. Resource is not null.",
+      "kind": "RETURN",
+      "condition": "(((args[0]==null)==false) && (args[0].isEmpty())) ? methodResultID == true : methodResultID == false"
+    },
+    "throwsTags": []
+  }
+]

--- a/src/test/resources/goal-output/commons-collections4-4.1/org.apache.commons.collections4.ClosureUtils_goal.json
+++ b/src/test/resources/goal-output/commons-collections4-4.1/org.apache.commons.collections4.ClosureUtils_goal.json
@@ -670,7 +670,7 @@
         "codeTags": [],
         "comment": "if the closures collection is empty",
         "kind": "THROWS",
-        "condition": "args[0].isEmpty()"
+        "condition": "((args[0]==null)==false)&&(args[0].isEmpty())"
       }
     ]
   },
@@ -1197,7 +1197,7 @@
         "codeTags": [],
         "comment": "if the map is empty",
         "kind": "THROWS",
-        "condition": "args[0].isEmpty()"
+        "condition": "((args[0]==null)==false)&&(args[0].isEmpty())"
       },
       {
         "exceptionType": {
@@ -1289,7 +1289,7 @@
         "codeTags": [],
         "comment": "if the map is empty",
         "kind": "THROWS",
-        "condition": "args[0].isEmpty()"
+        "condition": "((args[0]==null)==false)&&(args[0].isEmpty())"
       }
     ]
   }

--- a/src/test/resources/goal-output/commons-collections4-4.1/org.apache.commons.collections4.map.LRUMap_goal.json
+++ b/src/test/resources/goal-output/commons-collections4-4.1/org.apache.commons.collections4.map.LRUMap_goal.json
@@ -699,7 +699,7 @@
         "codeTags": [],
         "comment": "if the map is empty",
         "kind": "THROWS",
-        "condition": "args[0].isEmpty()"
+        "condition": "((args[0]==null)==false)&&(args[0].isEmpty())"
       }
     ]
   },
@@ -780,7 +780,7 @@
         "codeTags": [],
         "comment": "if the map is empty",
         "kind": "THROWS",
-        "condition": "args[0].isEmpty()"
+        "condition": "((args[0]==null)==false)&&(args[0].isEmpty())"
       }
     ]
   },

--- a/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.Line_goal.json
+++ b/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.Line_goal.json
@@ -86,7 +86,7 @@
         "codeTags": [],
         "comment": "if the points are equal",
         "kind": "THROWS",
-        "condition": "args[0].equals(args[1])"
+        "condition": "((args[0]==null)==false)&&(args[0].equals(args[1]))"
       }
     ]
   },
@@ -193,7 +193,7 @@
         "codeTags": [],
         "comment": "if the points are equal",
         "kind": "THROWS",
-        "condition": "args[0].equals(args[1])"
+        "condition": "((args[0]==null)==false)&&(args[0].equals(args[1]))"
       }
     ]
   },
@@ -268,7 +268,7 @@
         "codeTags": [],
         "comment": "if the points are equal",
         "kind": "THROWS",
-        "condition": "args[0].equals(args[1])"
+        "condition": "((args[0]==null)==false)&&(args[0].equals(args[1]))"
       }
     ]
   },

--- a/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.SubLine_goal.json
+++ b/src/test/resources/goal-output/commons-math3-3.6.1/org.apache.commons.math3.geometry.euclidean.threed.SubLine_goal.json
@@ -144,7 +144,7 @@
         "codeTags": [],
         "comment": "if the points are equal",
         "kind": "THROWS",
-        "condition": "args[0].equals(args[1])"
+        "condition": "((args[0]==null)==false)&&(args[0].equals(args[1]))"
       }
     ]
   },
@@ -214,7 +214,7 @@
         "codeTags": [],
         "comment": "if the points are equal",
         "kind": "THROWS",
-        "condition": "args[0].equals(args[1])"
+        "condition": "((args[0]==null)==false)&&(args[0].equals(args[1]))"
       }
     ]
   },

--- a/src/test/resources/goal-output/guava-19.0/com.google.common.collect.ConcurrentHashMultiset_goal.json
+++ b/src/test/resources/goal-output/guava-19.0/com.google.common.collect.ConcurrentHashMultiset_goal.json
@@ -31,7 +31,7 @@
         },
         "comment": "backing map for storing the elements in the multiset and their counts. It must be empty.",
         "kind": "PARAM",
-        "condition": "args[0].isEmpty()"
+        "condition": "((args[0]==null)==false)&&(args[0].isEmpty())"
       }
     ],
     "throwsTags": [
@@ -46,7 +46,7 @@
         ],
         "comment": "if countMap is not empty",
         "kind": "THROWS",
-        "condition": "(args[0].isEmpty()) == false"
+        "condition": "(((args[0]==null)==false)&&(args[0].isEmpty()))==false"
       }
     ]
   },

--- a/src/test/resources/goal-output/jgrapht-core-0.9.2/org.jgrapht.Graphs_goal.json
+++ b/src/test/resources/goal-output/jgrapht-core-0.9.2/org.jgrapht.Graphs_goal.json
@@ -283,7 +283,7 @@
     "returnTag": {
       "comment": "true if the target graph did not already contain the specified edge.",
       "kind": "RETURN",
-      "condition": "(args[0].containsEdge(args[2]))==false?methodResultID==true:methodResultID==false"
+      "condition": "(((args[0]==null)==false)&&(args[0].containsEdge(args[2])))==false?methodResultID==true:methodResultID==false"
     },
     "throwsTags": []
   },
@@ -693,7 +693,7 @@
         "codeTags": [],
         "comment": "if the specified vertices contains one or more null vertices, or if the specified vertex collection is null.",
         "kind": "THROWS",
-        "condition": "args[1].contains(null) || args[1]==null"
+        "condition": "((args[1]==null)==false)&&(args[1].contains(null))||args[1]==null"
       }
     ]
   },


### PR DESCRIPTION
With this changes, every time a method is invoked in a condition the receiver object is first checked for nullness (in the condition itself). 