### PR TITLE
Use a more generic pointcut

### DIFF
--- a/src/main/resources/TestCaseAspect.java
+++ b/src/main/resources/TestCaseAspect.java
@@ -5,7 +5,7 @@ import org.aspectj.lang.annotation.Aspect;
 @Aspect
 public class TestCaseAspect {
 
-  @Around("execution(@org.junit.Test * *(..))")
+  @Around("execution(* *(..))")
   public Object advice(ProceedingJoinPoint jp) throws Throwable {
     try {
       return jp.proceed();


### PR DESCRIPTION
The pointcut `execution(@org.junit.Test * *(..))` was supposed to target every method annotated with `org.junit.Test`. However, this was not the case. In particular, running the tutorial instructions showed that the pointcut wasn't matching any method.

As temporary solution, we use a way more generic pointcut `execution(* *(..))`. We should find a more efficient pointcut though.