### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
     packages:
       - openjdk-8-jdk
 
-install: travis_wait 30 ./gradlew unzipGlove unzipGloveModels
+install: ./gradlew unzipGlove unzipGloveModels
 
 script: ./gradlew build -PdisableShadowJar
 


### PR DESCRIPTION

According to [Build times out because no output was received](https://docs.travis-ci.com/user/common-build-problems/#build-times-out-because-no-output-was-received), we should carefully use travis_wait, as it may make the build unstable and extend the build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
